### PR TITLE
build script improvements

### DIFF
--- a/tools/build_release_uvision.bat
+++ b/tools/build_release_uvision.bat
@@ -15,7 +15,7 @@
 :: See the License for the specific language governing permissions and
 :: limitations under the License.
 ::
-
+rmdir /q /s uvision_release
 mkdir uvision_release
 git rev-parse --verify HEAD                     > uvision_release\git_info.txt
 git diff --no-ext-diff --quiet --exit-code      >> uvision_release\git_info.txt
@@ -32,4 +32,4 @@ progen generate -t uvision -b
 SET LEVEL=%ERRORLEVEL%
 python tools/copy_release_files.py
 if %errorlevel% neq 0 exit %errorlevel%
-exit %level%
+exit /B %level%

--- a/tools/build_release_uvision.bat
+++ b/tools/build_release_uvision.bat
@@ -33,3 +33,4 @@ SET LEVEL=%ERRORLEVEL%
 python tools/copy_release_files.py
 if %errorlevel% neq 0 exit %errorlevel%
 exit /B %level%
+


### PR DESCRIPTION
Clear output dir at outset to ensure all resulting artifacts are new

Use /B in exit command otherwise the script closes the console window when it completes. The previous behavior proved to be quite the pain. I'd run the script, and eventually the console would close, leaving me unable to see if the build failed or succeeded.