### PR TITLE
Fix --notestendpt handling

### DIFF
--- a/test/daplink_firmware.py
+++ b/test/daplink_firmware.py
@@ -80,7 +80,19 @@ class ProjectFirmwareBundle(firmware.FirmwareBundle):
     def __init__(self, directory, tool):
         tool_dir = os.path.abspath(directory + os.sep + 'projectfiles' +
                                    os.sep + tool)
+        errmsg = "Error: DAPLink projects are missing. Did " \
+                   "you forget to generate them by running " \
+                   "'progen generate -t %s'?\nExpecting them at %s" % (tool, tool_dir)
+
+        if not os.path.exists(tool_dir): 
+            print (errmsg)
+            exit(-1) 
+
         project_dir_list = os.listdir(tool_dir)
+        if not project_dir_list:
+            print (errmsg)
+            exit(-1) 
+        
         firmware_list = []
         for name in project_dir_list:
             build_dir = tool_dir + os.sep + name + os.sep + 'build'

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -573,7 +573,12 @@ def main():
     use_prebuilt = args.targetdir is not None
     use_compile_api = args.user is not None and args.password is not None
 
+    test_info = TestInfo('DAPLink')
+    
     # Validate args
+    
+    # See if user wants to test endpoints. If yes and he didn't provide 
+    # target test binaries, use the Compile API to build them 
     if not args.notestendpt:
         if not use_prebuilt and not use_compile_api:
             print("Endpoint test requires target test images.")
@@ -584,14 +589,12 @@ def main():
             print("  be specified so test images can be built with")
             print("  the compile API.")
             exit(-1)
-
-    firmware_explicitly_specified = len(args.firmware) != 0
-    test_info = TestInfo('DAPLink')
-    if args.targetdir is not None:
-        target_dir = args.targetdir
-    else:
-        target_dir = daplink_dir + os.sep + 'tmp'
-        build_target_bundle(target_dir, args.user, args.password, test_info)
+    
+        if args.targetdir is not None:
+            target_dir = args.targetdir
+        else:
+            target_dir = daplink_dir + os.sep + 'tmp'
+            build_target_bundle(target_dir, args.user, args.password, test_info)
 
     if os.path.exists(args.logdir):
         if args.force:
@@ -620,6 +623,7 @@ def main():
                 print('Unable to switch mode on board: %s' % board.unique_id)
 
     # Make sure firmware is present
+    firmware_explicitly_specified = len(args.firmware) != 0
     if firmware_explicitly_specified:
         all_firmware_names = set(fw.name for fw in all_firmware)
         firmware_missing = False

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
- 
+
 """
 DAPLink validation and testing tool
 
@@ -574,12 +574,12 @@ def main():
     use_compile_api = args.user is not None and args.password is not None
 
     test_info = TestInfo('DAPLink')
-    
+
     # Validate args
-    
-    # See if user wants to test endpoints. If yes and he didn't provide 
+
+    # See if user wants to test endpoints. If yes and he didn't provide
     # target test binaries, use the Compile API to build them
-    all_targets = None 
+    all_targets = None
     if not args.notestendpt:
         if not use_prebuilt and not use_compile_api:
             print("Endpoint test requires target test images.")
@@ -590,13 +590,13 @@ def main():
             print("  be specified so test images can be built with")
             print("  the compile API.")
             exit(-1)
-    
+
         if args.targetdir is not None:
             target_dir = args.targetdir
         else:
             target_dir = daplink_dir + os.sep + 'tmp'
             build_target_bundle(target_dir, args.user, args.password, test_info)
-            
+
         target_bundle = load_target_bundle(target_dir)
         all_targets = target_bundle.get_target_list()
 


### PR DESCRIPTION
The test logic was requiring a target executable even when --notestendpt was specified. The target binary is used only by the endpoint testing.