### PR TITLE
uVision pre/post script failure did not fail build

### DIFF
--- a/docs/DEVELOPERS-GUIDE.md
+++ b/docs/DEVELOPERS-GUIDE.md
@@ -57,3 +57,6 @@ DAPLink contains scripts to automate most of the steps of building a release.  I
 Note: A previous build can be reproduced by using the 'build_requirements.txt' of that build.
 To do this add the additional argument 'build_requirements.txt' when calling 'build_release_uvision.bat' in step 2.
 This will install and build with the exact version of the python packages used to create that build.
+
+## MDK
+If you want to use the MDK (uVision) IDE to work with the DAPLink code, you must launch it in the right environment. The project will fail to build otherwise. To launch uVision properly, use tools\launch_uv4.bat

--- a/records/tools/uvision.uvproj.tmpl
+++ b/records/tools/uvision.uvproj.tmpl
@@ -62,8 +62,6 @@
             <UserProg2Name></UserProg2Name>
             <UserProg1Dos16Mode>0</UserProg1Dos16Mode>
             <UserProg2Dos16Mode>0</UserProg2Dos16Mode>
-            <nStopU1X>0</nStopU1X>
-            <nStopU2X>0</nStopU2X>
           </BeforeCompile>
           <BeforeMake>
             <RunUserProg1>1</RunUserProg1>
@@ -72,6 +70,7 @@
             <UserProg2Name></UserProg2Name>
             <UserProg1Dos16Mode>0</UserProg1Dos16Mode>
             <UserProg2Dos16Mode>0</UserProg2Dos16Mode>
+            <nStopB1X>2</nStopB1X>
           </BeforeMake>
           <AfterMake>
             <RunUserProg1>1</RunUserProg1>
@@ -80,6 +79,7 @@
             <UserProg2Name></UserProg2Name>
             <UserProg1Dos16Mode>0</UserProg1Dos16Mode>
             <UserProg2Dos16Mode>0</UserProg2Dos16Mode>
+            <nStopA1X>2</nStopA1X>
           </AfterMake>
           <SelectedForBatchBuild>0</SelectedForBatchBuild>
           <SVCSIdString></SVCSIdString>

--- a/tools/build_release_uvision.bat
+++ b/tools/build_release_uvision.bat
@@ -16,21 +16,32 @@
 :: limitations under the License.
 ::
 rmdir /q /s uvision_release
+@if %errorlevel% neq 0 exit /B %errorlevel%
+
 mkdir uvision_release
+@if %errorlevel% neq 0 exit /B %errorlevel%
+
+@git --version 2> nul
+@if %errorlevel% neq 0 echo Error: git must be in PATH && exit /B %errorlevel%
+
 git rev-parse --verify HEAD                     > uvision_release\git_info.txt
 git diff --no-ext-diff --quiet --exit-code      >> uvision_release\git_info.txt
+
 echo Uncommitted Changes: %errorlevel%          >> uvision_release\git_info.txt
+
 virtualenv env
 call env\Scripts\activate
-REM use project requirements if not specified
+
+@REM use project requirements if not specified
 if [%1]==[] pip install -r requirements.txt
-REM use custom requirements if specified
+@REM use custom requirements if specified
 if not [%1]==[] pip install -r %1
 pip freeze                                      > uvision_release\build_requirements.txt
-REM build but continue if there are errors
-progen generate -t uvision -b
-SET LEVEL=%ERRORLEVEL%
-python tools/copy_release_files.py
-if %errorlevel% neq 0 exit %errorlevel%
-exit /B %level%
 
+@REM build but continue if there are errors
+progen generate -t uvision -b
+@SET level=%errorlevel%
+python tools/copy_release_files.py
+@if %errorlevel% neq 0 exit /B %errorlevel%
+
+@exit /B %level%

--- a/tools/launch_uv4.bat
+++ b/tools/launch_uv4.bat
@@ -28,12 +28,12 @@ setlocal
 
 :label0
 
-@rem See if we can find uVision. This logic is concistent with progen
+@rem See if we can find uVision. This logic is consistent with progen
 @set uv4exe=c:\Keil_v5\UV4\UV4.exe
 @if exist %uv4exe% goto label1
 	@if [%UV4%]==[] goto error_nomdk
-label1:
 set uv4exe=%UV4%
+label1:
 
 @set env_exists=0
 @if exist env set env_exists=1

--- a/tools/launch_uv4.bat
+++ b/tools/launch_uv4.bat
@@ -15,6 +15,12 @@
 :: See the License for the specific language governing permissions and
 :: limitations under the License.
 ::
+:: Launches uVision with the python environment needed to build DAPLink
+::
+:: git and python are expected to be in PATH. Project will fail to build otherwise
+:: 
+
+setlocal
 
 @if exist .gitignore goto label0
 	@echo Error: working directory must be root of DAPLink repository
@@ -22,33 +28,31 @@
 
 :label0
 
-rmdir /q /s uvision_release
-@if %errorlevel% neq 0 exit /B %errorlevel%
+@rem See if we can find uVision. This logic is concistent with progen
+@set uv4exe=c:\Keil_v5\UV4\UV4.exe
+@if exist %uv4exe% goto label1
+	@if [%UV4%]==[] goto error_nomdk
+label1:
+set uv4exe=%UV4%
 
-mkdir uvision_release
-@if %errorlevel% neq 0 exit /B %errorlevel%
-
-@git --version 2> nul
-@if %errorlevel% neq 0 echo Error: git must be in PATH && exit /B %errorlevel%
-
-git rev-parse --verify HEAD                     > uvision_release\git_info.txt
-git diff --no-ext-diff --quiet --exit-code      >> uvision_release\git_info.txt
-
-echo Uncommitted Changes: %errorlevel%          >> uvision_release\git_info.txt
-
-virtualenv env
+@set env_exists=0
+@if exist env set env_exists=1
+@if [%env_exists%]==[0] echo Creating python virtual environment && virtualenv env
 call env\Scripts\activate
 
+@echo Doing pip install
 @REM use project requirements if not specified
 if [%1]==[] pip install -r requirements.txt
 @REM use custom requirements if specified
 if not [%1]==[] pip install -r %1
-pip freeze                                      > uvision_release\build_requirements.txt
 
-@REM build but continue if there are errors
-progen generate -t uvision -b
-@SET level=%errorlevel%
-python tools/copy_release_files.py
-@if %errorlevel% neq 0 exit /B %errorlevel%
+:launch
+%uv4exe%
+exit /B 0
 
-@exit /B %level%
+:error_nomdk
+@echo Error: Keil MDK not installed or not found. If you installed it to a 
+@echo non-default echo location, you need to set environment variable UV4 to 
+@echo the path of the executable
+@exit /B 1
+

--- a/tools/post_build_script.bat
+++ b/tools/post_build_script.bat
@@ -16,13 +16,23 @@
 :: limitations under the License.
 ::
 
-set KEIL_ARM=%2
-set TOOLS=..\..\..\tools
-REM make sure fromelf is part of path
-set path=%KEIL_ARM%\ARMCC\bin;%path%
-set base_name= %1
-fromelf --bin %base_name%.axf -o %base_name%.bin
-fromelf --i32 %base_name%.axf -o %base_name%.hex
-python %TOOLS%\post_compute_crc.py %base_name%.hex %base_name%_crc
-REM Always return success
-exit 0
+@set PROJECT_DIR=%1
+@set KEIL_ARM=%2
+@set TOOLS=..\..\..\tools
+
+@REM add fromelf to PATH
+@set PATH=%KEIL_ARM%\ARMCC\bin;%path%
+
+@python --version 2> nul
+@if %errorlevel% neq 0 echo Error: python not in PATH. If you are manually building the project, make sure to launch uVision from the python venv && exit /B %errorlevel%
+
+fromelf --bin %PROJECT_DIR%.axf -o %PROJECT_DIR%.bin
+@if %errorlevel% neq 0 exit /b %errorlevel%
+
+fromelf --i32 %PROJECT_DIR%.axf -o %PROJECT_DIR%.hex
+@if %errorlevel% neq 0 exit /b %errorlevel%
+
+python %TOOLS%\post_compute_crc.py %PROJECT_DIR%.hex %PROJECT_DIR%_crc
+@if %errorlevel% neq 0 exit /b %errorlevel%
+
+@exit 0

--- a/tools/pre_build_script.bat
+++ b/tools/pre_build_script.bat
@@ -16,12 +16,16 @@
 :: limitations under the License.
 ::
 
-set TOOLS=..\..\..\tools
-set DIR=..\..\..\source\daplink
-REM  Create default version_git.h.  This is so the project 
-REM  builds if python is not installed
+@set TOOLS=..\..\..\tools
+@set DIR=..\..\..\source\daplink
+@REM  Create default version_git.h.  This is so the project 
+@REM  builds if python is not installed
 copy %DIR%\version_git_tmpl.txt %DIR%\version_git.h
-REM  Run python script to delete default version_git.h and create the real one
+@if %errorlevel% neq 0 exit /B %errorlevel%
+
+@python --version 2> nul
+@if %errorlevel% neq 0 echo Error: python not in PATH. If you are manually building the project, make sure to launch uVision from the python venv && exit /B %errorlevel%
+
+@REM  Run python script to delete default version_git.h and create the real one
 python %TOOLS%\pre_build_script.py
-REM Always return success
-exit 0
+@if %errorlevel% neq 0 exit /B %errorlevel%

--- a/tools/pre_build_script.py
+++ b/tools/pre_build_script.py
@@ -79,7 +79,7 @@ def pre_build():
     print "#> Checking for local changes"
     try:
         check_output("git diff --no-ext-diff --quiet --exit-code")
-    except CalledProcessError as e:
+    except CalledProcessError, WindowsError:
         git_has_changes = 1
     else:
         git_has_changes = 0


### PR DESCRIPTION
The daplink post/pre scripts invoked by the uVision builds lacked proper error checking and reporting. The projects, in turn, didn't care of the scripts failed. Both of these deficiencies are fixed by this PR. Also improved script output--removed a lot of clutter.