### PR TITLE
Update requirements.txt to fix build problems

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-project_generator>=0.8.3
+project_generator>=0.8.3,<0.8.16
 mbed_ls
 pyserial
 pyOCD>=0.7.0


### PR DESCRIPTION
Use a progen version below 0.9.0 since this introduces a bug preventing
some configurations of DAPLink from building.