### PR TITLE
Reset MSC endpoint on USB reset to fix bug

### DIFF
--- a/source/usb/msc/usbd_msc.c
+++ b/source/usb/msc/usbd_msc.c
@@ -1101,6 +1101,15 @@ void USBD_MSC_BulkOut(void)
     }
 }
 
+/** \brief  Handle Reset Events
+
+    The function handles Reset events.
+ */
+
+void USBD_MSC_Reset_Event(void)
+{
+    USBD_MSC_Reset();
+}
 
 /*
  *  USB Device MSC Bulk In Endpoint Event Callback

--- a/source/usb/usb_lib.c
+++ b/source/usb/usb_lib.c
@@ -957,6 +957,9 @@ void USBD_Reset_Event(void)
 #if    (USBD_CDC_ACM_ENABLE)
     USBD_CDC_ACM_Reset_Event();
 #endif
+#if    (USBD_MSC_ENABLE)
+    USBD_MSC_Reset_Event();
+#endif    
 }
 #endif
 #endif  /* ((USBD_CDC_ACM_ENABLE)) */
@@ -1093,6 +1096,9 @@ __weak __task void USBD_RTX_Device(void)
 #if (USBD_CDC_ACM_ENABLE)
             USBD_CDC_ACM_Reset_Event();
 #endif
+#if (USBD_MSC_ENABLE)
+            USBD_MSC_Reset_Event();
+#endif    
         }
 
         if (evt & USBD_EVT_SOF) {

--- a/source/usb/usbd_msc.h
+++ b/source/usb/usbd_msc.h
@@ -37,6 +37,8 @@ extern U8 *USBD_MSC_BlockBuf;
 
 /*--------------------------- Event handling routines ------------------------*/
 
+extern void USBD_MSC_Reset_Event(void);
+
 extern void USBD_MSC_EP_BULKIN_Event(U32 event);
 extern void USBD_MSC_EP_BULKOUT_Event(U32 event);
 extern void USBD_MSC_EP_BULK_Event(U32 event);


### PR DESCRIPTION
If a USB reset occurs in the middle of a SCSI command
mass storage can get in a state where it thinks the transfer
is still ongoing.  This cases new SCSI commands to get ignored
by the device.  This causes the PC to disable the MSC endpoint.

This patch fixes that problem by properly resetting the MSC endpoint
when a USB reset occurs.