### PR TITLE
Add support for progren version 0.8.16 and above

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-project_generator>=0.8.3,<0.8.16
+project_generator>=0.8.16,<0.9.0
 mbed_ls
 pyserial
 pyOCD>=0.7.0

--- a/source/hic_hal/freescale/k20dx/armcc/startup_MK20D5.s
+++ b/source/hic_hal/freescale/k20dx/armcc/startup_MK20D5.s
@@ -460,11 +460,11 @@ FOPT            EQU     0xFD
 FSEC            EQU     0xFE
 ;   </h>
 ; </h>
-                IF      :DEF:DAPLINK_IF
+            #if defined(DAPLINK_IF)
                 AREA    |.ARM.__at_0x8400|, CODE, READONLY
-                ELSE
+            #else
                 AREA    |.ARM.__at_0x400 |, CODE, READONLY
-                ENDIF
+            #endif
                 
                 DCB     BackDoorK0, BackDoorK1, BackDoorK2, BackDoorK3
                 DCB     BackDoorK4, BackDoorK5, BackDoorK6, BackDoorK7

--- a/source/hic_hal/freescale/kl26z/armcc/startup_MKL26Z4.s
+++ b/source/hic_hal/freescale/kl26z/armcc/startup_MKL26Z4.s
@@ -232,11 +232,11 @@ FOPT            EQU     0xFF
 FSEC            EQU     0xFE
 ;   </h>
 
-                IF      :DEF:DAPLINK_IF
+            #if defined(DAPLINK_IF)
                 AREA    |.ARM.__at_0x8400|, CODE, READONLY
-                ELSE
+            #else
                 AREA    |.ARM.__at_0x400 |, CODE, READONLY
-                ENDIF
+            #endif
                 
                 DCB     BackDoorK0, BackDoorK1, BackDoorK2, BackDoorK3
                 DCB     BackDoorK4, BackDoorK5, BackDoorK6, BackDoorK7


### PR DESCRIPTION
Use pre-processor syntax in startup_MK20D5.s rather than the
assembler specific configuration syntax.  This make DAPLink compatible
with the more recent versions of progen which only use preprocessor
options.