### PR TITLE
Add Thunderboard Wear as a target board

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -125,10 +125,10 @@ projects:
         - *module_if
         - *module_hic_lpc11u35
         - records/board/lpc824xpresso.yaml
-    lpc11u35_efm32gg_stk_if:
+    lpc11u35_thunderboard_wear_if:
         - *module_if
         - *module_hic_lpc11u35
-        - records/board/efm32gg_stk.yaml
+        - records/board/thunderboard_wear.yaml
     lpc11u35_archble_if:
         - *module_if
         - *module_hic_lpc11u35

--- a/records/board/thunderboard_wear.yaml
+++ b/records/board/thunderboard_wear.yaml
@@ -3,7 +3,7 @@ common:
         - source/target/siliconlabs/efm32gg
     sources:
         board:
-            - source/board/efm32gg_stk.c
+            - source/board/thunderboard_wear.c
         target:
             - source/target/siliconlabs/efm32gg/target.c
             - source/target/siliconlabs/target_reset.c

--- a/source/board/thunderboard_wear.c
+++ b/source/board/thunderboard_wear.c
@@ -1,6 +1,6 @@
 /**
- * @file    efm32gg_stk.c
- * @brief   board ID for the SiLabs Giant Gecko (not sure which board)
+ * @file    thunderboard_wear.c
+ * @brief   board ID for the Silicon Labs Thunderboard Wear
  *
  * DAPLink Interface Firmware
  * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
@@ -19,4 +19,4 @@
  * limitations under the License.
  */
 
-const char *board_id = "2015";
+const char *board_id = "2040";

--- a/test/info.py
+++ b/test/info.py
@@ -34,7 +34,7 @@ FIRMWARE_NAME_TO_BOARD_ID = {
     'kl26z_nrf51822_if': 0x9900,
     'lpc11u35_lpc812xpresso_if': 0x1050,
     'lpc11u35_ssci1114_if': 0x1114,
-    'lpc11u35_efm32gg_stk_if': 0x2015,
+    'lpc11u35_thunderboard_wear_if': 0x2040,
     'sam3u2c_nrf51dk_if': 0x1100,
     'k20dx_frdmk20dx_if': 0x0230,
     'k20dx_frdmkw24f_if': 0x0280,

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -27,7 +27,7 @@ optional arguments:
   --password PASSWORD   MBED password (required for compile-api)
   --firmwaredir FIRMWAREDIR
                         Directory with firmware images to test
-  --firmware {k20dx_k64f_if,lpc11u35_efm32gg_stk_if,...} (run script with --help to see full list)
+  --firmware {k20dx_k64f_if,lpc11u35_sscity_if,...} (run script with --help to see full list)
                         Firmware to test
   --logdir LOGDIR       Directory to log test results to
   --noloadif            Skip load step for interface.

--- a/tools/package_release_files.py
+++ b/tools/package_release_files.py
@@ -30,7 +30,7 @@ PROJECT_RELEASE_INFO = {
     ("lpc11u35_lpc812xpresso_if",   False,      0x0000,     "bin"       ),
     ("lpc11u35_lpc824xpresso_if",   False,      0x0000,     "bin"       ),
     ("lpc11u35_ssci1114_if",        False,      0x0000,     "bin"       ),
-    ("lpc11u35_efm32gg_stk_if",     False,      0x0000,     "bin"       ),
+    ("lpc11u35_thunderboard_wear_if", False,    0x0000,     "bin"       ),
     ("sam3u2c_nrf51dk_if",          True,       0x5000,     "bin"       ),
     ("k20dx_frdmk20dx_if",          True,       0x8000,     "bin"       ),
     ("k20dx_frdmkw24f_if",           True,       0x8000,     "bin"       ),


### PR DESCRIPTION
Replace the EFM32GG STK with the Thunderboard Wear.  The EFM32GG STK
doesn't have have an LPC11U35 natively and was just used as a
placeholder.