### PR TITLE
Remove target info from hid test

### DIFF
--- a/test/hid_test.py
+++ b/test/hid_test.py
@@ -37,85 +37,17 @@ def test_hid(workspace, parent_test):
     test_info = parent_test.create_subtest("HID test")
     board = workspace.board
     with MbedBoard.chooseBoard(board_id=board.get_unique_id()) as mbed_board:
-        addr = 0
-        size = 0
-
-        target_type = mbed_board.getTargetType()
         binary_file = workspace.target.bin_path
 
-        addr_bin = 0x00000000
+        memory_map = mbed_board.target.getMemoryMap()
+        ram_regions = [region for region in memory_map if region.type == 'ram']
+        ram_region = ram_regions[0]
+        rom_region = memory_map.getBootMemory()
 
-        if target_type == "lpc1768":
-            addr = 0x10000001
-            size = 0x1102
-            addr_flash = 0x10000
-        elif target_type == "lpc11u24":
-            addr = 0x10000001
-            size = 0x502
-            addr_flash = 0x4000
-        elif target_type == "kl25z":
-            addr = 0x20000001
-            size = 0x502
-            addr_flash = 0x10000
-        elif target_type == "kl28z":
-            addr = 0x20000001
-            size = 0x502
-            addr_flash = 0x10000
-        elif target_type == "k64f":
-            addr = 0x20000001
-            size = 0x502
-            addr_flash = 0x10000
-        elif target_type == "k22f":
-            addr = 0x20000001
-            size = 0x502
-            addr_flash = 0x10000
-        elif target_type == "k20d50m":
-            addr = 0x20000001
-            size = 0x502
-            addr_flash = 0x10000
-        elif target_type == "kl46z":
-            addr = 0x20000001
-            size = 0x502
-            addr_flash = 0x10000
-        elif target_type == "kl05z":
-            addr = 0x20000001
-            size = 0x502
-            addr_flash = 0x6000
-        elif target_type == "lpc800":
-            addr = 0x10000001
-            size = 0x502
-            addr_flash = 0x2000
-        elif target_type == "lpc11xx_32":
-            addr = 0x10000001
-            size = 0x502
-            addr_flash = 0x4000
-        elif target_type == "nrf51":
-            addr = 0x20000001
-            size = 0x502
-            addr_flash = 0x20000
-        elif target_type == "lpc4330":
-            addr = 0x10000001
-            size = 0x1102
-            addr_flash = 0x14010000
-            addr_bin = 0x14000000
-        elif target_type == "maxwsnenv":
-            addr = 0x20000001
-            size = 0x502
-            addr_flash = 0x10000
-        elif target_type == "max32600mbed":
-            addr = 0x20000001
-            size = 0x502
-            addr_flash = 0x10000
-        elif target_type == "w7500":
-            addr = 0x20000001
-            size = 0x1102
-            addr_flash = 0x00000000
-        elif target_type == "lpc824":
-            addr = 0x10000001
-            size = 0x502
-            addr_flash = 0x4000
-        else:
-            raise Exception("A board is not supported by this test script.")
+        addr = ram_region.start + 1
+        size = 0x502
+        addr_bin = rom_region.start
+        addr_flash = rom_region.start + rom_region.length // 2
 
         target = mbed_board.target
         flash = mbed_board.flash


### PR DESCRIPTION
Remove all the the target specific information from hid_test.py and
instead grab this info from pyOCD.