### PR TITLE
Fix bug with handling SWD protocol errors

### DIFF
--- a/source/daplink/cmsis-dap/SW_DP.c
+++ b/source/daplink/cmsis-dap/SW_DP.c
@@ -205,6 +205,7 @@ uint8_t SWD_Transfer##speed (uint32_t request, uint32_t *data) {                
   for (n = DAP_Data.swd_conf.turnaround + 32 + 1; n; n--) {                     \
     SW_CLOCK_CYCLE();                   /* Back off data phase */               \
   }                                                                             \
+  PIN_SWDIO_OUT_ENABLE();                                                       \
   PIN_SWDIO_OUT(1);                                                             \
   return (ack);                                                                 \
 }


### PR DESCRIPTION
When an SWD protocol error occurs the SWDIO line is unintentionally
left in input mode. This causes further transactions to fail.

This patch corrects this by setting SWDIO to output after a protocol
error. This also aligns with the more recent versions of CMSIS-DAP
(CMSIS-SP-00300-r4p5-00rel0) which contain this change.