### PR TITLE
atsam3u - Flush uart buffers on baud rate change

### DIFF
--- a/source/hic_hal/atmel/sam3u2c/uart.c
+++ b/source/hic_hal/atmel/sam3u2c/uart.c
@@ -335,6 +335,7 @@ int32_t uart_set_configuration(UART_Configuration *config)
                  | (0 <<  9)                  // Initially disable TxEmpty Interrupt
                  | (0 <<  4)                  // Initially disable ENDTx Interrupt
                  ;
+    _ResetBuffers();
     UART_IntrEna();
     return 1;
 }


### PR DESCRIPTION
Add code to flush the UART buffers when the baud rate is changed.
This fixes a bug in mbed testing where serial data on a failed test
can show up in a subsequent test.