### PR TITLE
Update serial test to make test cases modular

### DIFF
--- a/test/serial_test.py
+++ b/test/serial_test.py
@@ -18,8 +18,12 @@
 
 from __future__ import absolute_import
 from __future__ import division
-from threading import Thread
+import Queue
+import functools
 import serial
+import threading
+
+ERROR_TIMEOUT_SECONDS = 10.0
 
 
 def _same(d1, d2):
@@ -47,18 +51,116 @@ standard_baud = [
 timing_test_baud = standard_baud[3:]
 
 
-def calc_timeout(data, baud):
+def calc_timeout(length, baud):
     """Calculate a timeout given the data and baudrate
 
     Positional arguments:
-        data - data to be sent
+        length - size of data to be sent
         baud - baud rate to send data
 
     Calculate a reasonable timeout given the supplied parameters.
     This function adds slightly more time then is needed, to accont
     for latency and various configurations.
     """
-    return 12 * len(data) / float(baud) + 0.2
+    return 12 * float(length) / float(baud) + 0.2
+
+
+class SerialTester(object):
+    """Helper object to buffer serial and setup baud"""
+
+    def __init__(self, port):
+        self.raw_serial = serial.Serial(port)
+        self.raw_serial.write_timeout = ERROR_TIMEOUT_SECONDS
+        self._queue = Queue.Queue()
+        self._write_thread = threading.Thread(target=self._serial_main)
+        self._write_thread.start()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exception_type, value, traceback):
+        self._queue.put(None)
+        self._write_thread.join(ERROR_TIMEOUT_SECONDS)
+        assert not self._write_thread.isAlive(), "Thread join failed"
+        self.raw_serial.close()
+        self.raw_serial = None
+        return False
+
+    def new_session_with_baud(self, baud, parent_test):
+        """Start a new session by restarting target and setting baud"""
+        test_info = parent_test.create_subtest("Set Baud")
+
+        # Set baud to 115200
+        self.raw_serial.baudrate = 115200
+        self.raw_serial.timeout = 1.0
+
+        # Reset the target
+        self.raw_serial.sendBreak()
+
+        # Wait until the target is initialized
+        expected_resp = "{init}"
+        resp = self.read(len(expected_resp))
+        if not _same(resp, expected_resp):
+            test_info.failure("Fail on init: %s" % resp)
+            return False
+
+        # Change baudrate to that of the first test
+        command = "{baud:%i}" % baud
+        self.write(command)
+        resp = self.read(len(command))
+        if not _same(resp, command):
+            test_info.failure("Fail on baud command: %s" % resp)
+            return False
+
+        # Update baud of local serial port
+        self.raw_serial.baudrate = baud
+
+        # Read the response indicating that the baudrate
+        # on the target has changed
+        expected_resp = "{change}"
+        resp = self.read(len(expected_resp))
+        if not _same(resp, expected_resp):
+            test_info.failure("Fail on baud change %s" % resp)
+            return False
+
+        # Set default timeout
+        self.raw_serial.timeout = ERROR_TIMEOUT_SECONDS
+
+        # Success
+        return True
+
+    def read(self, length):
+        """Read serial data"""
+        return self.raw_serial.read(length)
+
+    def write(self, data):
+        """Write serial port data in the background"""
+        func = functools.partial(self.raw_serial.write, data[:])
+        self._queue.put(func)
+
+    def set_read_timeout(self, timeout):
+        """Set timeout for read operations"""
+        assert self._queue.empty(), "Queue must be empty to change timeout"
+        self.raw_serial.timeout = timeout
+
+    def flush(self):
+        """Wait for all writes to complete"""
+        self._queue.join()
+        assert self._queue.empty()
+
+    def _serial_main(self):
+        """Write helper thread"""
+        while True:
+            task = self._queue.get(True)
+            if task is None:
+                self._queue.task_done()
+                # End of processing is an empty task
+                break
+            try:
+                task()
+            except serial.SerialTimeoutException:
+                pass
+            self._queue.task_done()
 
 
 def test_serial(workspace, parent_test):
@@ -82,27 +184,16 @@ def test_serial(workspace, parent_test):
     # whole time.  Use the property 'baudrate' to change the baud
     # instead of opening a new instance.
 
-    # Generate a 8 KB block of dummy data
-    # and test a large block transfer
-    test_data = [i for i in range(0, 256)] * 4 * 8
-    test_data = str(bytearray(test_data))
-    baud = 115200
-    timeout = calc_timeout(test_data, baud)
-    with serial.Serial(port, baudrate=baud, timeout=timeout) as sp:
+    with SerialTester(port) as sp:
 
-        # Reset the target
-        sp.sendBreak()
+        # Generate a 8 KB block of dummy data
+        # and test a large block transfer
+        test_data = [i for i in range(0, 256)] * 4 * 8
+        test_data = str(bytearray(test_data))
+        sp.new_session_with_baud(115200, test_info)
 
-        # Wait until the target is initialized
-        expected_resp = "{init}"
-        resp = sp.read(len(expected_resp))
-        if not _same(resp, expected_resp):
-            test_info.failure("Fail on init: %s" % resp)
-
-        write_thread = Thread(target=sp.write, args=(test_data,))
-        write_thread.start()
+        sp.write(test_data)
         resp = sp.read(len(test_data))
-        write_thread.join()
         if _same(resp, test_data):
             test_info.info("Block test passed")
         else:
@@ -113,47 +204,16 @@ def test_serial(workspace, parent_test):
         test_data = [i for i in range(0, 256)] * 4 * 4
         test_data = str(bytearray(test_data))
         for baud in standard_baud:
-            # Set baud to 115200
-            sp.baudrate = 115200
-            sp.timeout = 1.0
 
-            # Reset the target
-            sp.sendBreak()
-
-            # Wait until the target is initialized
-            expected_resp = "{init}"
-            resp = sp.read(len(expected_resp))
-            if not _same(resp, expected_resp):
-                test_info.failure("Fail on init: %s" % resp)
-                continue
-
-            # Change baudrate to that of the first test
-            command = "{baud:%i}" % baud
-            sp.write(command)
-            resp = sp.read(len(command))
-            if not _same(resp, command):
-                test_info.failure("Fail on baud command: %s" % resp)
-                continue
-
-            # Update baud for test
             test_info.info("Testing baud %i" % baud)
-            test_time = calc_timeout(test_data, baud)
-            sp.baudrate = baud
-            sp.timeout = test_time
-
-            # Read the response indicating that the baudrate
-            # on the target has changed
-            expected_resp = "{change}"
-            resp = sp.read(len(expected_resp))
-            if not _same(resp, expected_resp):
-                test_info.failure("Fail on baud change %s" % resp)
+            success = sp.new_session_with_baud(baud, test_info)
+            if not success:
+                test_info.failure("Unable to setup session")
                 continue
 
             # Perform test
-            write_thread = Thread(target=sp.write, args=(test_data,))
-            write_thread.start()
+            sp.write(test_data)
             resp = sp.read(len(test_data))
-            write_thread.join()
             resp = bytearray(resp)
             if _same(test_data, resp):
                 test_info.info("Pass")
@@ -165,46 +225,17 @@ def test_serial(workspace, parent_test):
         # ------------------
         # Test sequence
         # 1. Send a block of data (vary size for the test)
-        # 2. Wait until 1 bytes is ready back
+        # 2. Wait until 1 byte is read back
         # 3. Write 1 byte
         # 4. Read back all data
         test_data = [i for i in range(0, 256)] * 4 * 4
         test_data = str(bytearray(test_data))
         for baud in timing_test_baud:
-            # Set baud to 115200
-            sp.baudrate = 115200
-            sp.timeout = 1.0
 
-            # Reset the target
-            sp.sendBreak()
-
-            # Wait until the target is initialized
-            expected_resp = "{init}"
-            resp = sp.read(len(expected_resp))
-            if not _same(resp, expected_resp):
-                test_info.failure("Fail on init: %s" % resp)
-                continue
-
-            # Change baudrate to that of the first test
-            command = "{baud:%i}" % baud
-            sp.write(command)
-            resp = sp.read(len(command))
-            if not _same(resp, command):
-                test_info.failure("Fail on baud command: %s" % resp)
-                continue
-
-            # Update baud for test
             test_info.info("Timing test baud %i" % baud)
-            test_time = calc_timeout(test_data, baud)
-            sp.baudrate = baud
-            sp.timeout = test_time
-
-            # Read the response indicating that the baudrate
-            # on the target has changed
-            expected_resp = "{change}"
-            resp = sp.read(len(expected_resp))
-            if not _same(resp, expected_resp):
-                test_info.failure("Fail on baud change %s" % resp)
+            success = sp.new_session_with_baud(baud, test_info)
+            if not success:
+                test_info.failure("Unable to setup session")
                 continue
 
             test_pass = True
@@ -217,7 +248,7 @@ def test_serial(workspace, parent_test):
                     resp += sp.read(1)
                     sp.write(data[-1:])
                     resp += sp.read(data_size)
-
+                    sp.flush()
                     if not _same(data, resp):
                         test_pass = False
                         test_info.info("fail size - %s" % data_size)


### PR DESCRIPTION
Create a SerialTester class to wrap common serial port operations.
Use this class to remove extra copy-paste code.