### PR TITLE
sam3u2c - return real free write size in uart buf

### DIFF
--- a/source/hic_hal/atmel/sam3u2c/uart.c
+++ b/source/hic_hal/atmel/sam3u2c/uart.c
@@ -353,17 +353,7 @@ int32_t uart_get_configuration(UART_Configuration *config)
 
 int32_t uart_write_free(void)
 {
-    int32_t bytesFree = 0;
-    bytesFree =  _NumBytesWriteFree(&_WriteBuffer);
-
-    //are there still bytes to send?
-    if (bytesFree < _CDC_BUFFER_SIZE) {
-        bytesFree = 0;
-        //pause to give NRF chip time to assert CTS line if needed
-        //os_dly_wait(4);
-    }
-
-    return bytesFree;
+    return _NumBytesWriteFree(&_WriteBuffer);
 }
 
 


### PR DESCRIPTION
Update the hal implementation of the sam3u2c to return the actual number of bytes free in the CDC buffer. Previous behavior returned that there was no space in the buffer if there were any bytes in it.