### PR TITLE
Exclude assert filenames from bootloader

### DIFF
--- a/records/hic_hal/k20dx.yaml
+++ b/records/hic_hal/k20dx.yaml
@@ -6,6 +6,7 @@ common:
         - CPU_MK20DX128VFM5
         - DAPLINK_HIC_ID=0x97969900  # DAPLINK_HIC_ID_K20DX
         - BL_TARGET_FLASH
+        - DAPLINK_NO_ASSERT_FILENAMES
     includes:
         - source/hic_hal/freescale/k20dx
         - source/hic_hal/freescale/iap/devices/MK20D5

--- a/records/hic_hal/kl26z.yaml
+++ b/records/hic_hal/kl26z.yaml
@@ -6,6 +6,7 @@ common:
         - CPU_MKL26Z128VLH4
         - DAPLINK_HIC_ID=0x97969901  # DAPLINK_HIC_ID_KL26
         - BL_TARGET_FLASH
+        - DAPLINK_NO_ASSERT_FILENAMES
     includes:
         - source/hic_hal/freescale/kl26z
         - source/hic_hal/freescale/iap/devices/MKL26Z4

--- a/source/daplink/util.h
+++ b/source/daplink/util.h
@@ -42,7 +42,13 @@ uint32_t util_div_round_up(uint32_t dividen, uint32_t divisor);
 uint32_t util_div_round_down(uint32_t dividen, uint32_t divisor);
 uint32_t util_div_round(uint32_t dividen, uint32_t divisor);
 
+#if defined(DAPLINK_IF)
+// Interface assert, with the filename enabled.
 #define util_assert(expression) _util_assert((expression), __FILE__, __LINE__)
+#else
+// Bootloader assert, filename disabled to save code size.
+#define util_assert(expression) _util_assert((expression), "(file)", __LINE__)
+#endif
 void _util_assert(bool expression, const char *filename, uint16_t line);
 
 void util_assert_clear(void);

--- a/source/daplink/util.h
+++ b/source/daplink/util.h
@@ -42,11 +42,11 @@ uint32_t util_div_round_up(uint32_t dividen, uint32_t divisor);
 uint32_t util_div_round_down(uint32_t dividen, uint32_t divisor);
 uint32_t util_div_round(uint32_t dividen, uint32_t divisor);
 
-#if defined(DAPLINK_IF)
-// Interface assert, with the filename enabled.
+#if !defined(DAPLINK_NO_ASSERT_FILENAMES)
+// With the filename enabled.
 #define util_assert(expression) _util_assert((expression), __FILE__, __LINE__)
 #else
-// Bootloader assert, filename disabled to save code size.
+// Filename disabled to save code size.
 #define util_assert(expression) _util_assert((expression), "(file)", __LINE__)
 #endif
 void _util_assert(bool expression, const char *filename, uint16_t line);


### PR DESCRIPTION
Do not include filename in asserts in the bootloader, to save code size. This fixes the K20DX128 bootloader build failure caused by the code size being >0x7c00 when the flash driver is updated to the latest version in KSDK 2.0 (see #128).
