### PR TITLE
Move release info into info.py

### DIFF
--- a/test/info.py
+++ b/test/info.py
@@ -15,18 +15,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
- 
+
 from __future__ import absolute_import
 
-# Add new HICs here
-HIC_STRING_TO_ID = {
-    'k20dx': 0x97969900,
-    'kl26z': 0x97969901,
-    'lpc11u35': 0x97969902,
-    'sam3u2c': 0x97969903,
+# Name of all projects ready for public release
+# and info on the file to be distributed
+PROJECT_RELEASE_INFO = {
+    # Project Name                          Legacy      Offset      Extension
+    ("k20dx_frdmk22f_if",                   True,       0x8000,     "bin"       ),
+    ("k20dx_frdmk64f_if",                   True,       0x5000,     "bin"       ),
+    ("kl26z_microbit_if",                   False,      0x8000,     "hex"       ),
+    ("lpc11u35_lpc812xpresso_if",           False,      0x0000,     "bin"       ),
+    ("lpc11u35_lpc824xpresso_if",           False,      0x0000,     "bin"       ),
+    ("lpc11u35_ssci1114_if",                False,      0x0000,     "bin"       ),
+    ("lpc11u35_efm32gg_stk_if",             False,      0x0000,     "bin"       ),
+    ("sam3u2c_mkit_dk_dongle_nrf5x_if",     True,       0x5000,     "bin"       ),
+    ("k20dx_frdmk20dx_if",                  True,       0x8000,     "bin"       ),
+    ("k20dx_frdmkw24f_if",                  True,       0x8000,     "bin"       ),
+    ("k20dx_frdmkl02z_if",                  True,       0x8000,     "bin"       ),
+    ("k20dx_frdmkl05z_if",                  True,       0x8000,     "bin"       ),
+    ("k20dx_frdmkl25z_if",                  True,       0x8000,     "bin"       ),
+    ("k20dx_frdmkl26z_if",                  True,       0x8000,     "bin"       ),
+    ("k20dx_frdmkl46z_if",                  True,       0x8000,     "bin"       ),
+    ("lpc11u35_archble_if",                 False,      0x0000,     "bin"       ),
+    ("lpc11u35_archpro_if",                 False,      0x0000,     "bin"       ),
+    #("lpc11u35_archmax_if",                False,      0x0000,     "bin"       ),  # Unsupported currently
+    ("lpc11u35_hrm1017_if",                 False,      0x0000,     "bin"       ),
+    ("lpc11u35_sscity_if",                  False,      0x0000,     "bin"       ),
+    ("lpc11u35_ssci824_if",                 False,      0x0000,     "bin"       ),
+    ("k20dx_rbl_if",                        True,       0x5000,     "bin"       ),
+    ("k20dx_rblnano_if",                    True,       0x5000,     "bin"       ),
+    ("lpc11u35_archlink_if",                False,      0x0000,     "bin"       ),
+    ("lpc11u35_tiny_if",                    False,      0x0000,     "bin"       ),
+    #("lpc11u35_c027_if",                   False,      0x0000      "bin"       ),  # Unsupported currently
 }
 
-
+# All supported configurations
 SUPPORTED_CONFIGURATIONS = [
     #   Board ID    Firmware                            Bootloader          Target
     (   0x200,      'k20dx_frdmkl25z_if',               'k20dx_bl',         'KL25Z'                         ),
@@ -65,11 +89,13 @@ SUPPORTED_CONFIGURATIONS = [
     (   0x9900,     'kl26z_microbit_if',                'kl26z_bl',         'Microbit'                      ),
 ]
 
-BOARD_ID_TO_BUILD_TARGET = {config[0]: config[3] for config in
-                            SUPPORTED_CONFIGURATIONS}
-FIRMWARE_SET = set((config[1] for config in SUPPORTED_CONFIGURATIONS))
-TARGET_SET = set((target[3] for target in SUPPORTED_CONFIGURATIONS if
-                  target[3] is not None))
+# Add new HICs here
+HIC_STRING_TO_ID = {
+    'k20dx': 0x97969900,
+    'kl26z': 0x97969901,
+    'lpc11u35': 0x97969902,
+    'sam3u2c': 0x97969903,
+}
 
 BOARD_ID_LOCKED_WHEN_ERASED = set([
     0x0231,  # K22F
@@ -79,10 +105,6 @@ BOARD_ID_LOCKED_WHEN_ERASED = set([
     0x0220,  # KL46Z
     0x0210,  # KL05Z
 ])
-
-TARGET_WITH_COMPILE_API_LIST = [config[3] for config in
-                                SUPPORTED_CONFIGURATIONS if
-                                config[3] is not None]
 
 #Hack until these targets have an image with a valid vector table
 TARGET_WITH_BAD_VECTOR_TABLE_LIST = [
@@ -99,3 +121,13 @@ TARGET_WITH_BAD_VECTOR_TABLE_LIST = [
     'Seeed-Tiny-BLE',
     'Seeed-Arch-Link',
 ]
+
+BOARD_ID_TO_BUILD_TARGET = {config[0]: config[3] for config in
+                            SUPPORTED_CONFIGURATIONS}
+FIRMWARE_SET = set((config[1] for config in SUPPORTED_CONFIGURATIONS))
+TARGET_SET = set((target[3] for target in SUPPORTED_CONFIGURATIONS if
+                  target[3] is not None))
+
+TARGET_WITH_COMPILE_API_LIST = [config[3] for config in
+                                SUPPORTED_CONFIGURATIONS if
+                                config[3] is not None]

--- a/tools/package_release_files.py
+++ b/tools/package_release_files.py
@@ -17,40 +17,18 @@
 #
 
 import os
+import sys
 import shutil
 import argparse
 
-# Name of all projects ready for public release
-# and info on the file to be distributed
-PROJECT_RELEASE_INFO = {
-    # Project Name                          Legacy      Offset      Extension
-    ("k20dx_frdmk22f_if",                   True,       0x8000,     "bin"       ),
-    ("k20dx_frdmk64f_if",                   True,       0x5000,     "bin"       ),
-    ("kl26z_microbit_if",                   False,      0x8000,     "hex"       ),
-    ("lpc11u35_lpc812xpresso_if",           False,      0x0000,     "bin"       ),
-    ("lpc11u35_lpc824xpresso_if",           False,      0x0000,     "bin"       ),
-    ("lpc11u35_ssci1114_if",                False,      0x0000,     "bin"       ),
-    ("lpc11u35_efm32gg_stk_if",             False,      0x0000,     "bin"       ),
-    ("sam3u2c_mkit_dk_dongle_nrf5x_if",     True,       0x5000,     "bin"       ),
-    ("k20dx_frdmk20dx_if",                  True,       0x8000,     "bin"       ),
-    ("k20dx_frdmkw24f_if",                  True,       0x8000,     "bin"       ),
-    ("k20dx_frdmkl02z_if",                  True,       0x8000,     "bin"       ),
-    ("k20dx_frdmkl05z_if",                  True,       0x8000,     "bin"       ),
-    ("k20dx_frdmkl25z_if",                  True,       0x8000,     "bin"       ),
-    ("k20dx_frdmkl26z_if",                  True,       0x8000,     "bin"       ),
-    ("k20dx_frdmkl46z_if",                  True,       0x8000,     "bin"       ),
-    ("lpc11u35_archble_if",                 False,      0x0000,     "bin"       ),
-    ("lpc11u35_archpro_if",                 False,      0x0000,     "bin"       ),
-    #("lpc11u35_archmax_if",                False,      0x0000,     "bin"       ),  # Unsupported currently
-    ("lpc11u35_hrm1017_if",                 False,      0x0000,     "bin"       ),
-    ("lpc11u35_sscity_if",                  False,      0x0000,     "bin"       ),
-    ("lpc11u35_ssci824_if",                 False,      0x0000,     "bin"       ),
-    ("k20dx_rbl_if",                        True,       0x5000,     "bin"       ),
-    ("k20dx_rblnano_if",                    True,       0x5000,     "bin"       ),
-    ("lpc11u35_archlink_if",                False,      0x0000,     "bin"       ),
-    ("lpc11u35_tiny_if",                    False,      0x0000,     "bin"       ),
-    #("lpc11u35_c027_if",                   False,      0x0000      "bin"       ),  # Unsupported currently
-}
+self_path = os.path.abspath(__file__)
+tools_dir = os.path.dirname(self_path)
+daplink_dir = os.path.dirname(tools_dir)
+test_dir = os.path.join(daplink_dir, "test")
+sys.path.append(test_dir)
+
+import info
+
 
 def main():
     parser = argparse.ArgumentParser(description='Package a release for distribution')
@@ -64,7 +42,7 @@ def main():
     build_number = "%04i" % args.version
 
     os.mkdir(output_dir)
-    for prj_name, legacy, offset, extension in PROJECT_RELEASE_INFO:
+    for prj_name, legacy, offset, extension in info.PROJECT_RELEASE_INFO:
         legacy_str = "_legacy" if legacy else ""
         source_offset_str = "_0x%04x" % offset if legacy else ""
         source_name = prj_name + "_crc" + legacy_str + source_offset_str + "." + extension


### PR DESCRIPTION
Move the information on which packages should be released into
package_release_files.py. With this change, all board specific info
used by the python scripts is located in info.py.