### PR TITLE
Update board_id for FRDM-KW24

### DIFF
--- a/source/board/frdmkw24f.c
+++ b/source/board/frdmkw24f.c
@@ -19,4 +19,4 @@
  * limitations under the License.
  */
 
-const char *board_id = "0280";
+const char *board_id = "0250";


### PR DESCRIPTION
Fixing a board id discrepancy.   FRDM-KW24 has been allocated 0250.   
A different platform, TWR-K24F120M, has been allocated 0280, so don't use that.