### PR TITLE
Adding NINA-B1 target board

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -66,6 +66,10 @@ projects:
         - *module_if
         - *module_hic_kl26z
         - records/board/microbit.yaml
+    kl26z_nina_b1_if:
+        - *module_if
+        - *module_hic_kl26z
+        - records/board/nina_b1.yaml
     k20dx_frdmk20dx_if:
         - *module_if
         - *module_hic_k20dx

--- a/records/board/nina_b1.yaml
+++ b/records/board/nina_b1.yaml
@@ -1,4 +1,8 @@
 common:
+    macros:
+        - IO_CONFIG_OVERRIDE
+    includes:
+        - source/board/override_mkl26z_reset
     sources:
         board:
             - source/board/nina_b1.c

--- a/records/board/nina_b1.yaml
+++ b/records/board/nina_b1.yaml
@@ -1,0 +1,7 @@
+common:
+    sources:
+        board:
+            - source/board/nina_b1.c
+        target:
+            - source/target/nordic/nrf5x/target.c
+            - source/target/nordic/target_reset.c

--- a/source/board/nina_b1.c
+++ b/source/board/nina_b1.c
@@ -21,7 +21,7 @@
 
 #include "target_config.h"
 
-const char *board_id = "1235";
+const char *board_id = "1238";
 
 void prerun_board_config(void)
 {

--- a/source/board/nina_b1.c
+++ b/source/board/nina_b1.c
@@ -1,0 +1,31 @@
+/**
+ * @file    nina_b1.c
+ * @brief   board ID for the u-blox NINA-B1 EVA maker board
+ *
+ * DAPLink Interface Firmware
+ * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "target_config.h"
+
+const char *board_id = "1235";
+
+void prerun_board_config(void)
+{
+	// NINA-B1 is based on nrf52
+	extern target_cfg_t target_device_nrf52;
+	target_device = target_device_nrf52;
+}

--- a/source/board/override_mkl26z_reset/IO_Config_Override.h
+++ b/source/board/override_mkl26z_reset/IO_Config_Override.h
@@ -1,0 +1,115 @@
+/**
+ * @file    IO_Config.h
+ * @brief   
+ *
+ * DAPLink Interface Firmware
+ * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Override all defines if IO_CONFIG_OVERRIDE is defined
+
+#ifndef __IO_CONFIG_OVERRIDE_H__
+#define __IO_CONFIG_OVERRIDE_H__
+
+#include "MKL26Z4.h"
+#include "compiler.h"
+#include "daplink.h"
+
+// This GPIO configuration is only valid for the KL26 HIC
+COMPILER_ASSERT(DAPLINK_HIC_ID == DAPLINK_HIC_ID_KL26);
+
+
+// Debug Port I/O Pins
+
+// SWCLK Pin                    PTC5(C5)
+#define PIN_SWCLK_PORT          PORTC
+#define PIN_SWCLK_GPIO          PTC
+#define PIN_SWCLK_BIT           (5)
+#define PIN_SWCLK               (1<<PIN_SWCLK_BIT)
+
+// SWDIO Pin                    PTC6(C6)
+#define PIN_SWDIO_PORT          PORTC
+#define PIN_SWDIO_GPIO          PTC
+#define PIN_SWDIO_BIT           (6)
+#define PIN_SWDIO               (1<<PIN_SWDIO_BIT)
+
+// nRESET Pin                   PTC8(C8)
+#define PIN_nRESET_PORT         PORTC
+#define PIN_nRESET_GPIO         PTC
+#define PIN_nRESET_BIT          (1/*8 DUE TO SMALLER PACKAGE*/)
+#define PIN_nRESET              (1<<PIN_nRESET_BIT)
+
+// PWR_REG_EN PTD2 - Not connected
+#define PIN_POWER_EN_PORT       PORTD
+#define PIN_POWER_EN_GPIO       PTD
+#define PIN_POWER_EN_BIT        (2)
+#define PIN_POWER_EN            (1<<PIN_POWER_EN_BIT)
+
+// VTRG_FAULT_B PTD3 - Not connected
+#define PIN_VTRG_FAULT_B_PORT   PORTD
+#define PIN_VTRG_FAULT_B_GPIO   PTD
+#define PIN_VTRG_FAULT_B_BIT    (7)
+#define PIN_VTRG_FAULT_B_EN     (1<<PIN_VTRG_FAULT_B_BIT)
+
+// Debug Unit LEDs
+
+// HID_LED PTD4
+#define PIN_HID_LED_PORT        PORTD
+#define PIN_HID_LED_GPIO        PTD
+#define PIN_HID_LED_BIT         (4) 
+#define PIN_HID_LED             (1<<PIN_HID_LED_BIT)
+
+// MSC_LED PTD5
+#define PIN_MSC_LED_PORT        PORTD
+#define PIN_MSC_LED_GPIO        PTD
+#define PIN_MSC_LED_BIT         (4)
+#define PIN_MSC_LED             (1<<PIN_MSC_LED_BIT)
+
+// CDC_LED PTD6
+#define PIN_CDC_LED_PORT        PORTD
+#define PIN_CDC_LED_GPIO        PTD
+#define PIN_CDC_LED_BIT         (4)
+#define PIN_CDC_LED             (1<<PIN_CDC_LED_BIT)
+
+// SW RESET BUTTON PTB1
+#define PIN_SW_RESET_PORT       PORTB
+#define PIN_SW_RESET_GPIO       PTB
+#define PIN_SW_RESET_BIT        (1)
+#define PIN_SW_RESET            (1<<PIN_SW_RESET_BIT)
+
+// Connected LED                Not available
+
+// Target Running LED           Not available
+
+// UART
+#define UART_PORT               PORTC
+#define UART_NUM                (1)
+// RX PTC3
+#define PIN_UART_RX_GPIO        PTC
+#define PIN_UART_RX_BIT         (3)
+#define PIN_UART_RX             (1<<PIN_UART_RX_BIT)
+#define PIN_UART_RX_MUX_ALT     (3)
+// TX PTC4
+#define PIN_UART_TX_GPIO        PTC
+#define PIN_UART_TX_BIT         (4)
+#define PIN_UART_TX             (1<<PIN_UART_TX_BIT)
+#define PIN_UART_TX_MUX_ALT     (3)
+
+#define UART                    UART1
+#define UART_RX_TX_IRQn         UART1_IRQn
+#define UART_RX_TX_IRQHandler   UART1_IRQHandler
+
+#endif

--- a/source/hic_hal/freescale/kl26z/IO_Config.h
+++ b/source/hic_hal/freescale/kl26z/IO_Config.h
@@ -19,6 +19,13 @@
  * limitations under the License.
  */
 
+// Override all defines if IO_CONFIG_OVERRIDE is defined
+#ifdef IO_CONFIG_OVERRIDE
+#include "IO_Config_Override.h"
+#ifndef __IO_CONFIG_H__
+#define __IO_CONFIG_H__
+#endif
+#endif
 
 #ifndef __IO_CONFIG_H__
 #define __IO_CONFIG_H__

--- a/test/info.py
+++ b/test/info.py
@@ -86,7 +86,7 @@ SUPPORTED_CONFIGURATIONS = [
     (   0x1114,     'lpc11u35_ssci1114_if',                     None,               'LPC1114FN28'                           ),
     (   0x1120,     'sam3u2c_mkit_dk_dongle_nrf5x_if',          'sam3u2c_bl',       'Nordic-nRF51-Dongle'                   ),
     (   0x1234,     'lpc11u35_c027_if',                         None,               'u-blox-C027'                           ),
-    (   0x1238,     'kl26z_nina_b1_if',                        'kl26z_bl',          'u-blox-NINA-B1'                        ),
+    (   0x1238,     'kl26z_nina_b1_if',                        'kl26z_bl',          None                                    ), # TODO - set target to 'UBLOX_EVA_NINA' when mbed-os supports this
     (   0x5050,     'lpc11u35_arm_watch_stm32f411_if',          None,               None                                    ),
     (   0x5051,     'lpc11u35_arm_watch_efm32_if',              None,               None                                    ),
     (   0x5052,     'lpc11u35_arm_watch_nrf51_if',              None,               None                                    ),

--- a/test/info.py
+++ b/test/info.py
@@ -47,6 +47,7 @@ PROJECT_RELEASE_INFO = {
     ("lpc11u35_archlink_if",                        False,      0x0000,     "bin"       ),
     ("lpc11u35_tiny_if",                            False,      0x0000,     "bin"       ),
     #("lpc11u35_c027_if",                           False,      0x0000,     "bin"       ),  # Unsupported currently
+    ("kl26z_nina_b1_if",                            False,      0x8000,     "bin"       ),
     ("lpc11u35_lpc4088dm_if",                       False,      0x0000,     "bin"       ),
     ("lpc11u35_lpc4088qsb_if",                      False,      0x0000,     "bin"       ),
     ('lpc11u35_ssci_chibi_if',                      False,      0x0000,     "bin"       ),
@@ -85,6 +86,7 @@ SUPPORTED_CONFIGURATIONS = [
     (   0x1114,     'lpc11u35_ssci1114_if',                     None,               'LPC1114FN28'                           ),
     (   0x1120,     'sam3u2c_mkit_dk_dongle_nrf5x_if',          'sam3u2c_bl',       'Nordic-nRF51-Dongle'                   ),
     (   0x1234,     'lpc11u35_c027_if',                         None,               'u-blox-C027'                           ),
+    (   0x1238,     'kl26z_nina_b1_if',                        'kl26z_bl',          'u-blox-NINA-B1'                        ),
     (   0x5050,     'lpc11u35_arm_watch_stm32f411_if',          None,               None                                    ),
     (   0x5051,     'lpc11u35_arm_watch_efm32_if',              None,               None                                    ),
     (   0x5052,     'lpc11u35_arm_watch_nrf51_if',              None,               None                                    ),


### PR DESCRIPTION
Adding u-blox NINA-B1 based board target. The DAPLink HDK is utilizing a KL26z.
