### PR TITLE
[Test] Adding delay for serial port initialization.

### DIFF
--- a/test/serial_test.py
+++ b/test/serial_test.py
@@ -23,6 +23,7 @@ import functools
 import serial
 import threading
 import time
+from time import sleep
 
 ERROR_TIMEOUT_SECONDS = 10.0
 
@@ -180,6 +181,9 @@ def test_serial(workspace, parent_test):
     board = workspace.board
     port = board.get_serial_port()
     test_info.info("Testing serial port %s" % port)
+
+    # Wait for the serial port to initialize
+    sleep(1)
 
     # Note: OSX sends a break command when a serial port is closed.
     # To avoid problems while testing keep the serial port open the


### PR DESCRIPTION
I'm working on a new target and the serial port is taking some extra time to initialize. Without any delay I get the following exception when the test tries to read from the CDC_ACM class.

> serial.serialutil.SerialException: device reports readiness to read but returned no data (device disconnected or multiple access on port?

The tests executing before the serial test are resetting the device and the serial test is executing before the HIC serial port is ready.
