### PR TITLE
Fix lpc11u35 lockup in USBD_WriteEP

### DIFF
--- a/source/hic_hal/nxp/lpc11u35/usbd_LPC11Uxx.c
+++ b/source/hic_hal/nxp/lpc11u35/usbd_LPC11Uxx.c
@@ -569,7 +569,8 @@ U32 USBD_ReadEP(U32 EPNum, U8 *pData, U32 size)
 U32 USBD_WriteEP(U32 EPNum, U8 *pData, U32 cnt)
 {
     U32 i;
-    U32 *dataptr, *ptr;
+    volatile U32 *ptr;
+    U32 *dataptr;
     ptr = GetEpCmdStatPtr(EPNum);
     EPNum &= ~0x80;
 


### PR DESCRIPTION
If USBD_WriteEP is called before the BUF_ACTIVE bit is cleared in the current endpoint then the code will get stuck in an infinite loop. This is because "ptr" is not volatile so the value it is pointed to is only
read once. This patch fixes that infinite loop by making the "ptr" variable volatile.