### PR TITLE
lpc11u35 - Improve USB voltage detection

### DIFF
--- a/source/hic_hal/nxp/lpc11u35/usbd_LPC11Uxx.c
+++ b/source/hic_hal/nxp/lpc11u35/usbd_LPC11Uxx.c
@@ -108,8 +108,7 @@ void USBD_Init(void)
                                  (1UL << 27);
     LPC_USB->DEVCMDSTAT  |= (1UL << 9);     /* PLL ON */
     LPC_IOCON->PIO0_3    &=  ~(0x1F);
-    LPC_IOCON->PIO0_3    |= (1UL << 3) |    /* pull-down */
-                            (1UL << 0);     /* Secondary function VBUS */
+    LPC_IOCON->PIO0_3    |= (1UL << 0);     /* Secondary function VBUS */
     LPC_IOCON->PIO0_6    &=   ~7;
     LPC_IOCON->PIO0_6    |= (1UL << 0);     /* Secondary function USB CON */
     LPC_SYSCON->PDRUNCFG &= ~((1UL << 8) |  /* USB PLL powered */


### PR DESCRIPTION
The pin PIO0_3 is used on some boards for USB voltage detection. This is typically used in conjunction with a voltage divider to bring 5v to 3.3v. The software pulldown on this pin can interfere with this voltage divider and on some boards this prevents detection of a USB connection. This patch removes this pulldown to allow those boards to operate normally.