### PR TITLE
[Flash] Make the drag-n-drop do a sector erase instead of mass.

### DIFF
--- a/source/daplink/drag-n-drop/flash_manager.h
+++ b/source/daplink/drag-n-drop/flash_manager.h
@@ -34,6 +34,7 @@ extern "C" {
 error_t flash_manager_init(const flash_intf_t *flash_intf);
 error_t flash_manager_data(uint32_t addr, const uint8_t *data, uint32_t size);
 error_t flash_manager_uninit(void);
+void flash_manager_set_page_erase(bool enabled);
 
 #ifdef __cplusplus
 }

--- a/source/daplink/drag-n-drop/iap_flash_intf.c
+++ b/source/daplink/drag-n-drop/iap_flash_intf.c
@@ -53,7 +53,7 @@ typedef enum {
 static error_t init(void);
 static error_t uninit(void);
 static error_t program_page(uint32_t addr, const uint8_t *buf, uint32_t size);
-static error_t erase_sector(uint32_t sector);
+static error_t erase_sector(uint32_t addr);
 static error_t erase_chip(void);
 static uint32_t program_page_min_size(uint32_t addr);
 static uint32_t erase_sector_size(uint32_t addr);

--- a/source/daplink/interface/target_flash.c
+++ b/source/daplink/interface/target_flash.c
@@ -35,7 +35,7 @@
 static error_t target_flash_init(void);
 static error_t target_flash_uninit(void);
 static error_t target_flash_program_page(uint32_t adr, const uint8_t *buf, uint32_t size);
-static error_t target_flash_erase_sector(uint32_t sector);
+static error_t target_flash_erase_sector(uint32_t addr);
 static error_t target_flash_erase_chip(void);
 static uint32_t target_flash_program_page_min_size(uint32_t addr);
 static uint32_t target_flash_erase_sector_size(uint32_t addr);
@@ -118,11 +118,16 @@ static error_t target_flash_program_page(uint32_t addr, const uint8_t *buf, uint
     return ERROR_SUCCESS;
 }
 
-static error_t target_flash_erase_sector(uint32_t sector)
+static error_t target_flash_erase_sector(uint32_t addr)
 {
     const program_target_t *const flash = target_device.flash_algo;
 
-    if (0 == swd_flash_syscall_exec(&flash->sys_call_s, flash->erase_sector, sector * target_device.sector_size, 0, 0, 0)) {
+    // Check to make sure the address is on a sector boundary
+    if ((addr % target_device.sector_size) != 0) {
+        return ERROR_ERASE_SECTOR;
+    }
+
+    if (0 == swd_flash_syscall_exec(&flash->sys_call_s, flash->erase_sector, addr, 0, 0, 0)) {
         return ERROR_ERASE_SECTOR;
     }
 

--- a/source/target/unsupported/atmel/target_flash.c
+++ b/source/target/unsupported/atmel/target_flash.c
@@ -100,9 +100,14 @@ target_flash_status_t target_flash_init(extension_t ext)
 }
 
 
-target_flash_status_t target_flash_erase_sector(unsigned int sector)
+target_flash_status_t target_flash_erase_sector(unsigned int addr)
 {
-    if (!swd_flash_syscall_exec(&flash.sys_call_param, flash.erase_sector, sector * target_device.sector_size, 0, 0, 0)) {
+    // Check to make sure the address is on a sector boundary
+    if ((addr % target_device.sector_size) != 0) {
+        return TARGET_FAIL_ERASE_SECTOR;
+    }
+
+    if (!swd_flash_syscall_exec(&flash.sys_call_param, flash.erase_sector, addr, 0, 0, 0)) {
         return TARGET_FAIL_ERASE_SECTOR;
     }
 
@@ -132,7 +137,7 @@ target_flash_status_t target_flash_program_page(uint32_t addr, uint8_t *buf, uin
 
     // we need to erase a sector
     if (addr % target_device.sector_size == 0) {
-        status = target_flash_erase_sector(addr / target_device.sector_size);
+        status = target_flash_erase_sector(addr);
 
         if (status != TARGET_OK) {
             return status;

--- a/source/target/unsupported/renesas/target_flash.c
+++ b/source/target/unsupported/renesas/target_flash.c
@@ -82,9 +82,14 @@ target_flash_status_t target_flash_init(extension_t ext)
     return TARGET_OK;
 }
 
-target_flash_status_t target_flash_erase_sector(unsigned int sector)
+target_flash_status_t target_flash_erase_sector(unsigned int addr)
 {
-    if (!swd_flash_syscall_exec(&flash.sys_call_param, flash.erase_sector, sector * target_device.sector_size, 0, 0, 0)) {
+    // Check to make sure the address is on a sector boundary
+    if ((addr % target_device.sector_size) != 0) {
+        return TARGET_FAIL_ERASE_SECTOR;
+    }
+
+    if (!swd_flash_syscall_exec(&flash.sys_call_param, flash.erase_sector, addr, 0, 0, 0)) {
         return TARGET_FAIL_ERASE_SECTOR;
     }
 
@@ -107,7 +112,7 @@ target_flash_status_t target_flash_program_page(uint32_t addr, uint8_t *buf, uin
 
     // we need to erase a sector
     if (addr % target_device.sector_size == 0) {
-        status = target_flash_erase_sector(addr / target_device.sector_size);
+        status = target_flash_erase_sector(addr);
 
         if (status != TARGET_OK) {
             return status;


### PR DESCRIPTION
The drag-n-drop programming function currently does a mass erase when re-programming a target device. Having it do a sector erase will prevent bootloader/ROM code already in the flash from being erased. 