### PR TITLE
[Test] Moving the setting of serial timeout.

### DIFF
--- a/test/serial_test.py
+++ b/test/serial_test.py
@@ -263,6 +263,7 @@ def test_serial(workspace, parent_test):
             # Discard data
             sp.read(1024)
         # Read any leftover data
+        sp.flush()
         sp.raw_serial.baudrate = 115200
         sp.set_read_timeout(1.0)
         sp.read(128 * len(standard_baud))


### PR DESCRIPTION
I was getting an exception when setting the timeout. The code reads to flush out any leftover data, but changing the timeout when something is in the queue causes an exception. 

`
  File "DAPLink/test/serial_test.py", line 144, in set_read_timeout
    assert self._queue.empty(), "Queue must be empty to change timeout"
AssertionError: Queue must be empty to change timeout
`