### PR TITLE
K20DX128 HIC pin fixes

### DIFF
--- a/source/hic_hal/freescale/k20dx/DAP_config.h
+++ b/source/hic_hal/freescale/k20dx/DAP_config.h
@@ -1,6 +1,6 @@
 /**
  * @file    DAP_config.h
- * @brief   
+ * @brief
  *
  * DAPLink Interface Firmware
  * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
@@ -396,11 +396,13 @@ static inline void DAP_SETUP(void)
                   SIM_SCGC5_PORTC_MASK |  /* Enable Port C Clock */
                   SIM_SCGC5_PORTD_MASK;   /* Enable Port D Clock */
     /* Configure I/O pin SWCLK */
-    PIN_SWCLK_PORT->PCR[PIN_SWCLK_BIT]         = PORT_PCR_MUX(1);    /* GPIO */
+    PIN_SWCLK_PORT->PCR[PIN_SWCLK_BIT]         = PORT_PCR_MUX(1) |   /* GPIO */
+             PORT_PCR_DSE_MASK; /* High drive strength */
     PIN_SWCLK_GPIO->PSOR  = 1 << PIN_SWCLK_BIT;                      /* High level */
     PIN_SWCLK_GPIO->PDDR |= 1 << PIN_SWCLK_BIT;                      /* Output */
     /* Configure I/O pin SWDIO_OUT */
-    PIN_SWDIO_OUT_PORT->PCR[PIN_SWDIO_OUT_BIT] = PORT_PCR_MUX(1);    /* GPIO */
+    PIN_SWDIO_OUT_PORT->PCR[PIN_SWDIO_OUT_BIT] = PORT_PCR_MUX(1) |   /* GPIO */
+             PORT_PCR_DSE_MASK; /* High drive strength */
     PIN_SWDIO_OUT_GPIO->PSOR  = 1 << PIN_SWDIO_OUT_BIT;              /* High level */
     PIN_SWDIO_OUT_GPIO->PDDR |= 1 << PIN_SWDIO_OUT_BIT;              /* Output */
     /* Configure I/O pin SWDIO_IN */
@@ -409,11 +411,13 @@ static inline void DAP_SETUP(void)
             PORT_PCR_PS_MASK;   /* Pull-up */
     PIN_SWDIO_IN_GPIO->PDDR &= ~(1 << PIN_SWDIO_IN_BIT);             /* Input */
     /* Configure I/O pin SWDIO_NOE */
-    PIN_SWDIO_NOE_PORT->PCR[PIN_SWDIO_NOE_BIT] = PORT_PCR_MUX(1);    /* GPIO */
+    PIN_SWDIO_NOE_PORT->PCR[PIN_SWDIO_NOE_BIT] = PORT_PCR_MUX(1) |   /* GPIO */
+             PORT_PCR_DSE_MASK; /* High drive strength */
     PIN_SWDIO_NOE_GPIO->PSOR  = 1 << PIN_SWDIO_NOE_BIT;              /* High level */
     PIN_SWDIO_NOE_GPIO->PDDR |= 1 << PIN_SWDIO_NOE_BIT;              /* Output */
     /* Configure I/O pin SWD_NOE */
-    PIN_SWD_NOE_PORT->PCR[PIN_SWD_NOE_BIT]     = PORT_PCR_MUX(1);    /* GPIO */
+    PIN_SWD_NOE_PORT->PCR[PIN_SWD_NOE_BIT]     = PORT_PCR_MUX(1) |   /* GPIO */
+             PORT_PCR_DSE_MASK; /* High drive strength */
     PIN_SWD_NOE_GPIO->PSOR  = 1 << PIN_SWD_NOE_BIT;                  /* High level */
     PIN_SWD_NOE_GPIO->PDDR |= 1 << PIN_SWD_NOE_BIT;                  /* Output */
     /* Configure I/O pin nRESET */

--- a/source/hic_hal/freescale/k20dx/DAP_config.h
+++ b/source/hic_hal/freescale/k20dx/DAP_config.h
@@ -170,6 +170,7 @@ static inline void PORT_OFF(void)
     PIN_SWDIO_NOE_GPIO->PSOR = 1 << PIN_SWDIO_NOE_BIT;
     PIN_SWD_NOE_GPIO->PSOR   = 1 << PIN_SWD_NOE_BIT;
     PIN_nRESET_GPIO->PSOR    = 1 << PIN_nRESET_BIT;
+    PIN_nRESET_GPIO->PDDR &= ~PIN_nRESET; //input
     PIN_nRESET_PORT->PCR[PIN_nRESET_BIT] |= PORT_PCR_ISF_MASK;
     PIN_nRESET_PORT->PCR[PIN_nRESET_BIT] = PORT_PCR_PS_MASK | PORT_PCR_PE_MASK | PORT_PCR_PFE_MASK | PORT_PCR_MUX(1);
 }
@@ -426,7 +427,7 @@ static inline void DAP_SETUP(void)
             PORT_PCR_PS_MASK |  /* Pull-up */
             PORT_PCR_ODE_MASK;  /* Open-drain */
     PIN_nRESET_GPIO->PSOR  = 1 << PIN_nRESET_BIT;                    /* High level */
-    PIN_nRESET_GPIO->PDDR |= 1 << PIN_nRESET_BIT;                    /* Output */
+    PIN_nRESET_GPIO->PDDR &= ~(1 << PIN_nRESET_BIT);                    /* Input */
     /* Configure LED */
     LED_CONNECTED_PORT->PCR[LED_CONNECTED_BIT] = PORT_PCR_MUX(1)  |  /* GPIO */
             PORT_PCR_ODE_MASK;  /* Open-drain */


### PR DESCRIPTION
- Enable high drive strength for SWD pins on the K20DX128 HIC.
- Fix problem with nRESET being driven when SWD was disabled on the K20DX128 HIC. This resolves a long standing problem where you couldn't use DAPLink for the virtual serial port while simultaneously using another debug probe connected to the target SWD header.
