### PR TITLE
Fix target reset problems on lpc11u35 interface

### DIFF
--- a/source/daplink/interface/swd_host.c
+++ b/source/daplink/interface/swd_host.c
@@ -859,10 +859,13 @@ uint8_t swd_set_target_state_hw(TARGET_RESET_STATE state)
 {
     uint32_t val;
     swd_init();
+    swd_init_debug();
 
     switch (state) {
         case RESET_HOLD:
             swd_set_target_reset(1);
+            swd_uninit_debug();
+            swd_off();
             break;
 
         case RESET_RUN:
@@ -870,6 +873,7 @@ uint8_t swd_set_target_state_hw(TARGET_RESET_STATE state)
             os_dly_wait(2);
             swd_set_target_reset(0);
             os_dly_wait(2);
+            swd_uninit_debug();
             swd_off();
             break;
 
@@ -956,10 +960,13 @@ uint8_t swd_set_target_state_sw(TARGET_RESET_STATE state)
 {
     uint32_t val;
     swd_init();
+    swd_init_debug();
 
     switch (state) {
         case RESET_HOLD:
             swd_set_target_reset(1);
+            swd_uninit_debug();
+            swd_off();
             break;
 
         case RESET_RUN:
@@ -967,6 +974,7 @@ uint8_t swd_set_target_state_sw(TARGET_RESET_STATE state)
             os_dly_wait(2);
             swd_set_target_reset(0);
             os_dly_wait(2);
+            swd_uninit_debug();
             swd_off();
             break;
 

--- a/source/daplink/interface/target_flash.c
+++ b/source/daplink/interface/target_flash.c
@@ -77,10 +77,10 @@ static error_t target_flash_uninit(void)
     // Resume the target if configured to do so
     if (config_get_auto_rst()) {
         target_set_state(RESET_RUN);
+    } else {
+        target_set_state(RESET_HOLD);
     }
 
-    swd_uninit_debug();
-    swd_off();
     return ERROR_SUCCESS;
 }
 

--- a/source/target/nordic/target_reset.c
+++ b/source/target/nordic/target_reset.c
@@ -46,8 +46,6 @@ uint8_t target_set_state(TARGET_RESET_STATE state)
 void swd_set_target_reset(uint8_t asserted)
 {
     if (asserted) {
-        swd_init_debug();
-
         //Set POWER->RESET on NRF to 1
         if (!swd_write_ap(AP_TAR, 0x40000000 + 0x544)) {
             return;

--- a/source/target/nordic/target_reset_nrf5x_sam3u2c.c
+++ b/source/target/nordic/target_reset_nrf5x_sam3u2c.c
@@ -57,8 +57,6 @@ void swd_set_target_reset(uint8_t asserted)
                                 && board_id[3] == '1') ? 1 : 0;  // ID 1101 is the nrf52-dk
     if (nrf52_dk_is_used) {
         if (asserted) {
-            swd_init_debug();
-            
             swd_read_ap(0x010000FC, &ap_index_return);
             if (ap_index_return == 0x02880000) {
                 // Device has CTRL-AP
@@ -70,11 +68,8 @@ void swd_set_target_reset(uint8_t asserted)
                 swd_write_memory(0xE000ED0C, (uint8_t *)&swd_mem_write_data, 4);
                 //os_dly_wait(1);
             }
-            swd_uninit_debug();
         }
         else {
-            swd_init_debug();
-            
             swd_read_ap(0x010000FC, &ap_index_return);
             if (ap_index_return == 0x02880000) {
                 // Device has CTRL-AP
@@ -83,13 +78,10 @@ void swd_set_target_reset(uint8_t asserted)
             else {
                 // No CTRL-AP - Soft reset has been performed
             }
-            swd_uninit_debug();
         }
     }
     else {
         if (asserted) {
-            swd_init_debug();
-            
             /*  There is no reset pin on the nRF51822, so we need to use special reset routine, 
                 SWDCLK and SWDIO/nRESET needs to be kept low for a minimum of 100uS. Called of this func needs to make sure of this. */
             //Set POWER->RESET on NRF to 1


### PR DESCRIPTION
On some boards reset doesn't work correctly when the debug module is turned off while the target is halted. This patch fixes that problem by always turning on debug in swd_set_target_state_*.

This problem can be reproduced by programming the target on a LPC812 Xpresso. The target will not start running when the reset button is pressed. The board needs to be disconnected and reconnected for the target to run.

This problem was introduced in the commit
c074a58052873296fa9f918341cb0e06e6ab0c03 -
Added swd_uninit_debug() function. Used new function in reset routine
for nRF5x, as well as target_flash.c uninit.