### PR TITLE
Fix msd assert caused by processing after xfer

### DIFF
--- a/source/daplink/drag-n-drop/vfs_manager.c
+++ b/source/daplink/drag-n-drop/vfs_manager.c
@@ -334,6 +334,9 @@ void usbd_msc_write_sect(uint32_t sector, uint8_t *buf, uint32_t num_of_sectors)
     // indicate msc activity
     main_blink_msc_led(MAIN_LED_OFF);
     vfs_write(sector, buf, num_of_sectors);
+    if (TRASNFER_FINISHED == file_transfer_state.transfer_state) {
+        return;
+    }
     file_data_handler(sector, buf, num_of_sectors);
 }
 
@@ -382,6 +385,10 @@ static void file_change_handler(const vfs_filename_t filename, vfs_file_change_t
 {
     vfs_mngr_printf("vfs_manager file_change_handler(name=%*s, file=%p, change=%i)\r\n", 11, filename, file, change);
     vfs_user_file_change_handler(filename, change, file, new_file_data);
+    if (TRASNFER_FINISHED == file_transfer_state.transfer_state) {
+        // If the transfer is finished stop further processing
+        return;
+    }
 
     if (VFS_FILE_CHANGED == change) {
         if (file == file_transfer_state.file_to_program) {


### PR DESCRIPTION
Stop further file processing once a mass storage transfer is finished. This fixes an assert sometimes caused when data arrives after a transfer has been completed.