### PR TITLE
Improve fifo overflow

### DIFF
--- a/docs/MSD_COMMANDS.md
+++ b/docs/MSD_COMMANDS.md
@@ -67,3 +67,10 @@ bootloader updates are allowed only in automation-allowed mode.
 
 `auto_off.cfg` This file turns off automation-allowed mode. This mode
 is off by default
+
+
+`ovfl_on.cfg` This file turns on serial overflow reporting. If the host PC is not reading
+data fast enough from DAPLink and an overflow occurs the text ```<DAPLink:Overflow>```
+will show up in the serial data. Serial overflow reporting is turned off by default.
+
+`ovfl_off.cfg` This file turns off serial overflow reporting.

--- a/source/daplink/circ_buf.c
+++ b/source/daplink/circ_buf.c
@@ -1,0 +1,137 @@
+/**
+ * @file    circular_buffer.c
+ * @brief   Implementation of a circular buffer
+ *
+ * DAPLink Interface Firmware
+ * Copyright (c) 2016-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "circ_buf.h"
+
+#include "cortex_m.h"
+#include "macro.h"
+#include "util.h"
+
+void circ_buf_init(circ_buf_t *circ_buf, uint8_t *buffer, uint32_t size)
+{
+    cortex_int_state_t state;
+    state = cortex_int_get_and_disable();
+
+    circ_buf->buf = buffer;
+    circ_buf->size = size;
+    circ_buf->head = 0;
+    circ_buf->tail = 0;
+
+    cortex_int_restore(state);
+}
+
+void circ_buf_push(circ_buf_t *circ_buf, uint8_t data)
+{
+    cortex_int_state_t state;
+    state = cortex_int_get_and_disable();
+
+    circ_buf->buf[circ_buf->tail] = data;
+    circ_buf->tail += 1;
+    if (circ_buf->tail >= circ_buf->size) {
+        util_assert(circ_buf->tail == circ_buf->size);
+        circ_buf->tail = 0;
+    }
+
+    // Assert no overflow
+    util_assert(circ_buf->head != circ_buf->tail);
+
+    cortex_int_restore(state);
+}
+
+uint8_t circ_buf_pop(circ_buf_t *circ_buf)
+{
+    uint8_t data;
+    cortex_int_state_t state;
+
+    state = cortex_int_get_and_disable();
+
+    // Assert buffer isn't empty
+    util_assert(circ_buf->head != circ_buf->tail);
+
+    data = circ_buf->buf[circ_buf->head];
+    circ_buf->head += 1;
+    if (circ_buf->head >= circ_buf->size) {
+        util_assert(circ_buf->head == circ_buf->size);
+        circ_buf->head = 0;
+    }
+
+    cortex_int_restore(state);
+    
+    return data;
+}
+
+uint32_t circ_buf_count_used(circ_buf_t *circ_buf)
+{
+    uint32_t cnt;
+    cortex_int_state_t state;
+
+    state = cortex_int_get_and_disable();
+
+    if (circ_buf->tail >= circ_buf->head) {
+        cnt = circ_buf->tail - circ_buf->head;
+    } else {
+        cnt = circ_buf->tail + circ_buf->size - circ_buf->head;
+    }
+
+    cortex_int_restore(state);
+    return cnt;
+}
+    
+uint32_t circ_buf_count_free(circ_buf_t *circ_buf)
+{
+    uint32_t cnt;
+    cortex_int_state_t state;
+
+    state = cortex_int_get_and_disable();
+
+    cnt = circ_buf->size - circ_buf_count_used(circ_buf) - 1;
+
+    cortex_int_restore(state);
+    return cnt;
+}
+
+uint32_t circ_buf_read(circ_buf_t *circ_buf, uint8_t *data, uint32_t size)
+{
+    uint32_t cnt;
+    uint32_t i;
+
+    cnt = circ_buf_count_used(circ_buf);
+    cnt = MIN(size, cnt);
+    for (i = 0; i < cnt; i++) {
+        data[i] = circ_buf_pop(circ_buf);
+    }
+
+    return cnt;
+}
+
+uint32_t circ_buf_write(circ_buf_t *circ_buf, const uint8_t *data, uint32_t size)
+{
+    uint32_t cnt;
+    uint32_t i;
+
+    cnt = circ_buf_count_free(circ_buf);
+    cnt = MIN(size, cnt);
+    for (i = 0; i < cnt; i++) {
+        circ_buf_push(circ_buf, data[i]);
+    }
+
+    return cnt;
+}

--- a/source/daplink/circ_buf.h
+++ b/source/daplink/circ_buf.h
@@ -1,0 +1,64 @@
+/**
+ * @file    circ_buf.h
+ * @brief   Implementation of a circular buffer
+ *
+ * DAPLink Interface Firmware
+ * Copyright (c) 2016-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CIRC_BUF_H
+#define CIRC_BUF_H
+
+#include "stdbool.h"
+#include "stdint.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    uint32_t head;
+    uint32_t tail;
+    uint32_t size;
+    uint8_t *buf;
+} circ_buf_t;
+
+// Initialize or reinitialize a circular buffer
+void circ_buf_init(circ_buf_t *circ_buf, uint8_t *buffer, uint32_t size);
+
+// Push a byte into the circular buffer
+void circ_buf_push(circ_buf_t *circ_buf, uint8_t data);
+
+// Return a byte from the circular buffer
+uint8_t circ_buf_pop(circ_buf_t *circ_buf);
+
+// Get the number of bytes in the circular buffer
+uint32_t circ_buf_count_used(circ_buf_t *circ_buf);
+
+// Get the number of free spots left in the circular buffer
+uint32_t circ_buf_count_free(circ_buf_t *circ_buf);
+
+// Attempt to read size bytes from the buffer. Return the number of bytes read
+uint32_t circ_buf_read(circ_buf_t *circ_buf, uint8_t *data, uint32_t size);
+
+// Attempt to write size bytes to the buffer. Return the number of bytes written
+uint32_t circ_buf_write(circ_buf_t *circ_buf, const uint8_t *data, uint32_t size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/source/daplink/drag-n-drop/vfs_user.c
+++ b/source/daplink/drag-n-drop/vfs_user.c
@@ -160,6 +160,12 @@ void vfs_user_file_change_handler(const vfs_filename_t filename, vfs_file_change
         } else if (!memcmp(filename, "ERASE   ACT", sizeof(vfs_filename_t))) {
             erase_target();
             vfs_mngr_fs_remount();
+        } else if (!memcmp(filename, "OVFL_ON CFG", sizeof(vfs_filename_t))) {
+            config_set_overflow_detect(true);
+            vfs_mngr_fs_remount();
+        } else if (!memcmp(filename, "OVFL_OFFCFG", sizeof(vfs_filename_t))) {
+            config_set_overflow_detect(false);
+            vfs_mngr_fs_remount();
         }
     }
 
@@ -231,6 +237,9 @@ static uint32_t read_file_details_txt(uint32_t sector_offset, uint8_t *data, uin
     pos += util_write_string(buf + pos, "\r\n");
     pos += util_write_string(buf + pos, "Automation allowed: ");
     pos += util_write_string(buf + pos, config_get_automation_allowed() ? "1" : "0");
+    pos += util_write_string(buf + pos, "\r\n");
+    pos += util_write_string(buf + pos, "Overflow detection: ");
+    pos += util_write_string(buf + pos, config_get_overflow_detect() ? "1" : "0");
     pos += util_write_string(buf + pos, "\r\n");
     // Current mode
     mode_str = daplink_is_bootloader() ? "Bootloader" : "Interface";

--- a/source/daplink/settings/settings.h
+++ b/source/daplink/settings/settings.h
@@ -39,8 +39,10 @@ void config_init(void);
 // Get/set settings residing in flash
 void config_set_auto_rst(bool on);
 void config_set_automation_allowed(bool on);
+void config_set_overflow_detect(bool on);
 bool config_get_auto_rst(void);
 bool config_get_automation_allowed(void);
+bool config_get_overflow_detect(void);
 
 // Get/set settings residing in shared ram
 void config_ram_set_hold_in_bl(bool hold);

--- a/source/daplink/settings/settings_rom.c
+++ b/source/daplink/settings/settings_rom.c
@@ -43,13 +43,14 @@ typedef struct __attribute__((__packed__)) cfg_setting {
     // Configurable values
     uint8_t auto_rst;
     uint8_t automation_allowed;
+    uint8_t overflow_detect;
 
     // Add new members here
 
 } cfg_setting_t;
 
 // Make sure FORMAT in generate_config.py is updated if size changes
-COMPILER_ASSERT(sizeof(cfg_setting_t) == 8);
+COMPILER_ASSERT(sizeof(cfg_setting_t) == 9);
 
 // Sector buffer must be as big or bigger than settings
 COMPILER_ASSERT(sizeof(cfg_setting_t) < SECTOR_BUFFER_SIZE);
@@ -68,6 +69,7 @@ static cfg_setting_t config_rom_copy;
 static const cfg_setting_t config_default = {
     .auto_rst = 0,
     .automation_allowed = 0,
+    .overflow_detect = 0,
 };
 
 // Buffer for data to flash
@@ -155,6 +157,12 @@ void config_set_automation_allowed(bool on)
     program_cfg(&config_rom_copy);
 }
 
+void config_set_overflow_detect(bool on)
+{
+    config_rom_copy.overflow_detect = on;
+    program_cfg(&config_rom_copy);
+}
+
 bool config_get_auto_rst()
 {
     return config_rom_copy.auto_rst;
@@ -163,4 +171,9 @@ bool config_get_auto_rst()
 bool config_get_automation_allowed(void)
 {
     return config_rom_copy.automation_allowed;
+}
+
+bool config_get_overflow_detect()
+{
+    return config_rom_copy.overflow_detect;
 }

--- a/source/daplink/settings/settings_rom_stub.c
+++ b/source/daplink/settings/settings_rom_stub.c
@@ -38,6 +38,11 @@ void config_set_automation_allowed(bool on)
     // Do nothing
 }
 
+void config_set_overflow_detect(bool on)
+{
+    // Do nothing
+}
+
 bool config_get_auto_rst()
 {
     return false;
@@ -46,4 +51,9 @@ bool config_get_auto_rst()
 bool config_get_automation_allowed()
 {
     return true;
+}
+
+bool config_get_overflow_detect()
+{
+    return false;
 }

--- a/source/hic_hal/atmel/sam3u2c/uart.c
+++ b/source/hic_hal/atmel/sam3u2c/uart.c
@@ -26,6 +26,7 @@
 #include "circ_buf.h"
 #include "cortex_m.h"
 #include "util.h"
+#include "settings.h" // for config_get_overflow_detect
 
 #define  BUFFER_SIZE  512
 #define _CPU_CLK_HZ   SystemCoreClock
@@ -394,8 +395,10 @@ void UART_IRQHandler(void)
         cnt = (int32_t)circ_buf_count_free(&read_buffer) - RX_OVRF_MSG_SIZE;
         if (cnt > 0) {
             circ_buf_push(&read_buffer, data);
-        } else if (0 == cnt) {
+        } else if ((0 == cnt) && config_get_overflow_detect()) {
             circ_buf_write(&read_buffer, (uint8_t*)RX_OVRF_MSG, RX_OVRF_MSG_SIZE);
+        } else {
+            // Drop character
         }
 
         //If this was the last available byte on the buffer then assert RTS

--- a/source/hic_hal/atmel/sam3u2c/uart.c
+++ b/source/hic_hal/atmel/sam3u2c/uart.c
@@ -23,9 +23,16 @@
 
 #include "sam3u.h"
 #include "uart.h"
+#include "circ_buf.h"
+#include "cortex_m.h"
+#include "util.h"
 
+#define  BUFFER_SIZE  512
 #define _CPU_CLK_HZ   SystemCoreClock
-#define _CDC_BUFFER_SIZE (512)
+
+#define RX_OVRF_MSG         "<DAPLink:Overflow>\n"
+#define RX_OVRF_MSG_SIZE    (sizeof(RX_OVRF_MSG) - 1)
+
 
 #define MIN(a, b)     (((a) < (b)) ? (a) : (b))
 #define MAX(a, b)     (((a) > (b)) ? (a) : (b))
@@ -109,14 +116,11 @@
 #define PIOA_FELLSR          (*(volatile U32*) (PIOA_BASE_ADDR + 0xD0)) // Falling Edge/Low Level Select Register
 #define PIOA_REHLSR          (*(volatile U32*) (PIOA_BASE_ADDR + 0xD4)) // Rising Edge/High Level Select Register
 
-typedef struct {
-    U8 acBuffer[_CDC_BUFFER_SIZE + 1];   // Buffer is max. filled to BufferSize - 1
-    U8 *pRead;
-    U8 *pWrite;
-} CIRCBUFFER;
+circ_buf_t write_buffer;
+uint8_t write_buffer_data[BUFFER_SIZE];
+circ_buf_t read_buffer;
+uint8_t read_buffer_data[BUFFER_SIZE];
 
-static CIRCBUFFER _WriteBuffer;
-static CIRCBUFFER _ReadBuffer;
 static U32        _Baudrate;
 static U8         _FlowControl;
 static U8         _UARTChar0;   // Use static here since PDC starts transferring the byte when we already left this function
@@ -151,21 +155,15 @@ static int _SetBaudrate(U32 Baudrate)
 
 static void _Send1(void)
 {
-    U8 *pWrapAround;
-    U8 *pRead;
+    // Assert that there is data in the buffer
+    util_assert(circ_buf_count_used(&write_buffer) > 0);
+
     //
     // Use PDC for transferring the byte to the UART since direct write to UART_THR does not seem to work properly.
     //
     PIOA->PIO_MDDR = (1 << UART_TX_PIN); //Disable open-drain on TX pin
-    pRead = _WriteBuffer.pRead;
-    _UARTChar0 = *pRead++;
-    pWrapAround = (U8 *)(_WriteBuffer.acBuffer + sizeof(_WriteBuffer.acBuffer));
+    _UARTChar0 = circ_buf_pop(&write_buffer);
 
-    if (pRead == pWrapAround) {
-        pRead = _WriteBuffer.acBuffer;
-    }
-
-    _WriteBuffer.pRead = pRead;
     _TxInProgress = 1;
     UART_PDC_TPR  = (U32)&_UARTChar0;
     UART_PDC_TCR  = 1;
@@ -175,27 +173,10 @@ static void _Send1(void)
 
 static void _ResetBuffers(void)
 {
-    _WriteBuffer.pRead  = _WriteBuffer.acBuffer;
-    _WriteBuffer.pWrite = _WriteBuffer.acBuffer;
-    _ReadBuffer.pRead   = _ReadBuffer.acBuffer;
-    _ReadBuffer.pWrite  = _ReadBuffer.acBuffer;
+    //TODO - assert that transmit is off
+    circ_buf_init(&write_buffer, write_buffer_data, sizeof(write_buffer_data));
+    circ_buf_init(&read_buffer, read_buffer_data, sizeof(read_buffer_data));
     _TxInProgress       = 0;
-}
-
-
-static int32_t _NumBytesWriteFree(CIRCBUFFER *pBuffer)
-{
-    //
-    // Return free space in buffer
-    //
-    int32_t v;
-    v = (int32_t)(pBuffer->pRead - pBuffer->pWrite - 1);
-
-    if (v < 0) {
-        v += sizeof(pBuffer->acBuffer);
-    }
-
-    return v;
 }
 
 void UART_IntrEna(void)
@@ -218,7 +199,7 @@ void uart_software_flow_control()
 
     if (((PIOA->PIO_PDSR >> BIT_CDC_USB2UART_CTS) & 1) == 0) {
         _TxInProgress = 0;
-        v = _CDC_BUFFER_SIZE - _NumBytesWriteFree(&_WriteBuffer); // NumBytes in write buffer
+        v = circ_buf_count_used(&write_buffer); // NumBytes in write buffer
 
         if (v == 0) {  // No more characters to send ?: Disable further tx interrupts
             UART_IER = UART_TX_INT_FLAG;
@@ -230,6 +211,7 @@ void uart_software_flow_control()
         UART_IDR = UART_TX_INT_FLAG;
     }
 }
+
 int32_t uart_initialize(void)
 {
     //
@@ -353,110 +335,51 @@ int32_t uart_get_configuration(UART_Configuration *config)
 
 int32_t uart_write_free(void)
 {
-    return _NumBytesWriteFree(&_WriteBuffer);
+    return circ_buf_count_free(&write_buffer);
 }
 
 
 int32_t uart_write_data(uint8_t *data, uint16_t size)
 {
-    uint16_t NumBytesWritten;
-    uint16_t NumBytesAtOnce;
-    U8 *pWrapAround;
-    U8 *pWrite;
-    //
-    // Early out in case nothing needs to be written or buffer is full
-    //
-    size = MIN(_NumBytesWriteFree(&_WriteBuffer), size);
+    cortex_int_state_t state;
+    uint32_t cnt;
 
-    if (size == 0) {  // Early out
-        return 0;
-    }
+    cnt = circ_buf_write(&write_buffer, data, size);
 
     //
-    // Copy data into buffer. Also consider wrap-around
+    // Atomically trigger transfer if not already in progress
     //
-    NumBytesWritten = size;
-    pWrite = _WriteBuffer.pWrite;
-    pWrapAround = (U8 *)(_WriteBuffer.acBuffer + sizeof(_WriteBuffer.acBuffer));
-
-    if (size) {
-        do {
-            NumBytesAtOnce = MIN(size, (int)(pWrapAround - pWrite));   // Copy as much as possible and consider wrap-around
-            memcpy(pWrite, data, NumBytesAtOnce);
-            pWrite += NumBytesAtOnce;
-
-            if (pWrite == pWrapAround) {
-                pWrite = _WriteBuffer.acBuffer;
-            }
-
-            size -= NumBytesAtOnce;
-            data += NumBytesAtOnce;
-        } while (size);
-    }
-
-    _WriteBuffer.pWrite = pWrite;
-
-    //
-    // Trigger transfer if not already in progress
-    //
+    state = cortex_int_get_and_disable();
     if (_TxInProgress == 0 && ((PIOA->PIO_PDSR >> BIT_CDC_USB2UART_CTS) & 1) == 0) {
         _Send1();
     }
+    cortex_int_restore(state);
 
-    return NumBytesWritten;
+    return cnt;
 }
 
 int32_t uart_read_data(uint8_t *data, uint16_t size)
 {
-    uint16_t NumBytesRead;
-    uint16_t NumBytesAtOnce;
-    uint16_t v;
-    uint16_t writeFreeBytes;
-    U8 *pWrapAround;
-    U8 *pRead;
-    writeFreeBytes = _NumBytesWriteFree(&_ReadBuffer);
+    cortex_int_state_t state;
+    uint32_t cnt;
 
-    //Check if RTS had been asserted, if there is space on the buffer then deassert RTS
-    if (writeFreeBytes > 0 && ((PIOA->PIO_PDSR >> BIT_CDC_USB2UART_RTS) & 1)) {
+    cnt = circ_buf_read(&read_buffer, data, size);
+
+    // Atomically check if RTS had been asserted, if there is space on the buffer then deassert RTS
+    state = cortex_int_get_and_disable();
+    if ((circ_buf_count_free(&read_buffer) > RX_OVRF_MSG_SIZE) && ((PIOA->PIO_PDSR >> BIT_CDC_USB2UART_RTS) & 1)) {
         PIOA->PIO_CODR = 1 << BIT_CDC_USB2UART_RTS;
     }
+    cortex_int_restore(state);
 
-    v = _CDC_BUFFER_SIZE - writeFreeBytes;
-    size = MIN(v, size);
-
-    if (size == 0) {  // Early out
-        return 0;
-    }
-
-    NumBytesRead = size;
-    pWrapAround = (U8 *)(_ReadBuffer.acBuffer + sizeof(_ReadBuffer.acBuffer));
-    pRead = _ReadBuffer.pRead;
-
-    if (size) {
-        do {
-            NumBytesAtOnce = MIN(size, (int)(pWrapAround - pRead));   // Copy as much as possible and consider wrap-around
-            memcpy(data, pRead, NumBytesAtOnce);
-            pRead += NumBytesAtOnce;
-
-            if (pRead == pWrapAround) {
-                pRead = _ReadBuffer.acBuffer;
-            }
-
-            size -= NumBytesAtOnce;
-            data += NumBytesAtOnce;
-        } while (size);
-    }
-
-    _ReadBuffer.pRead = pRead;
-    return NumBytesRead;
+    return cnt;
 }
 
 void UART_IRQHandler(void)
 {
     int Status;
-    uint32_t v;
-    U8 c;
-    U8 *pWrapAround;
+    int32_t cnt;
+    U8 data;
     Status = UART_SR;                                 // Examine status register
 
     if (Status & UART_RX_ERR_FLAGS) {                 // In case of error: Set RSTSTA to reset status bits PARE, FRAME, OVRE and RXBRK
@@ -467,21 +390,17 @@ void UART_IRQHandler(void)
     // Handle Rx event
     //
     if (Status & UART_RXRDY_FLAG) {                   // Data received?
-        c = UART_RHR;
-        v = _NumBytesWriteFree(&_ReadBuffer);
+        data = UART_RHR;
+        cnt = (int32_t)circ_buf_count_free(&read_buffer) - RX_OVRF_MSG_SIZE;
+        if (cnt > 0) {
+            circ_buf_push(&read_buffer, data);
+        } else if (0 == cnt) {
+            circ_buf_write(&read_buffer, (uint8_t*)RX_OVRF_MSG, RX_OVRF_MSG_SIZE);
+        }
 
-        if (v) {
-            *_ReadBuffer.pWrite++ = c;
-            pWrapAround = (U8 *)(_ReadBuffer.acBuffer + sizeof(_ReadBuffer.acBuffer));
-
-            if (_ReadBuffer.pWrite == pWrapAround) {
-                _ReadBuffer.pWrite = _ReadBuffer.acBuffer;
-            }
-
-            //If this was the last available byte on the buffer then assert RTS
-            if (v == 1) {
-                PIOA->PIO_SODR = 1 << BIT_CDC_USB2UART_RTS;
-            }
+        //If this was the last available byte on the buffer then assert RTS
+        if (cnt == 1) {
+            PIOA->PIO_SODR = 1 << BIT_CDC_USB2UART_RTS;
         }
     }
 
@@ -489,9 +408,8 @@ void UART_IRQHandler(void)
     // Handle Tx event
     //
     if (Status & UART_IMR & UART_TX_INT_FLAG) {       // Byte has been send by UART
-        v = _CDC_BUFFER_SIZE - _NumBytesWriteFree(&_WriteBuffer); // NumBytes in write buffer
-
-        if (v == 0) {                               // No more characters to send ?: Disable further tx interrupts
+        cnt = circ_buf_count_used(&write_buffer); // NumBytes in write buffer
+        if (cnt == 0) {                               // No more characters to send ?: Disable further tx interrupts
             UART_IDR = UART_TX_INT_FLAG;
             PIOA->PIO_MDER = (1 << UART_TX_PIN);    //enable open-drain
             _TxInProgress = 0;

--- a/source/hic_hal/freescale/k20dx/uart.c
+++ b/source/hic_hal/freescale/k20dx/uart.c
@@ -25,35 +25,27 @@
 #include "uart.h"
 #include "util.h"
 #include "cortex_m.h"
+#include "circ_buf.h"
 
 extern uint32_t SystemCoreClock;
 
 static void clear_buffers(void);
 
-// Size must be 2^n for using quick wrap around
-#define  BUFFER_SIZE (512)
+#define RX_OVRF_MSG         "<DAPLink:Overflow>\n"
+#define RX_OVRF_MSG_SIZE    (sizeof(RX_OVRF_MSG) - 1)
+#define BUFFER_SIZE         (512)
 
-struct {
-    uint8_t  data[BUFFER_SIZE];
-    volatile uint32_t idx_in;
-    volatile uint32_t idx_out;
-    volatile uint32_t cnt_in;
-    volatile uint32_t cnt_out;
-} write_buffer, read_buffer;
+
+circ_buf_t write_buffer;
+uint8_t write_buffer_data[BUFFER_SIZE];
+circ_buf_t read_buffer;
+uint8_t read_buffer_data[BUFFER_SIZE];
 
 void clear_buffers(void)
 {
     util_assert(!(UART1->C2 & UART_C2_TIE_MASK));
-    memset((void *)&read_buffer, 0xBB, sizeof(read_buffer.data));
-    read_buffer.idx_in = 0;
-    read_buffer.idx_out = 0;
-    read_buffer.cnt_in = 0;
-    read_buffer.cnt_out = 0;
-    memset((void *)&write_buffer, 0xBB, sizeof(read_buffer.data));
-    write_buffer.idx_in = 0;
-    write_buffer.idx_out = 0;
-    write_buffer.cnt_in = 0;
-    write_buffer.cnt_out = 0;
+    circ_buf_init(&write_buffer, write_buffer_data, sizeof(write_buffer_data));
+    circ_buf_init(&read_buffer, read_buffer_data, sizeof(read_buffer_data));
 }
 
 int32_t uart_initialize(void)
@@ -168,35 +160,19 @@ int32_t uart_get_configuration(UART_Configuration *config)
 
 int32_t uart_write_free(void)
 {
-    return BUFFER_SIZE - (write_buffer.cnt_in - write_buffer.cnt_out);
+    return circ_buf_count_free(&write_buffer);
 }
 
 int32_t uart_write_data(uint8_t *data, uint16_t size)
 {
-    uint32_t cnt;
-    int16_t  len_in_buf;
     cortex_int_state_t state;
+    uint32_t cnt;
 
-    if (size == 0) {
-        return 0;
-    }
-
-    cnt = 0;
-
-    while (size--) {
-        len_in_buf = write_buffer.cnt_in - write_buffer.cnt_out;
-
-        if (len_in_buf < BUFFER_SIZE) {
-            write_buffer.data[write_buffer.idx_in++] = *data++;
-            write_buffer.idx_in &= (BUFFER_SIZE - 1);
-            write_buffer.cnt_in++;
-            cnt++;
-        }
-    }
+    cnt = circ_buf_write(&write_buffer, data, size);
 
     // Atomically enable TX
     state = cortex_int_get_and_disable();
-    if (write_buffer.cnt_in != write_buffer.cnt_out) {
+    if (circ_buf_count_used(&write_buffer)) {
         UART1->C2 |= UART_C2_TIE_MASK;
     }
     cortex_int_restore(state);
@@ -206,26 +182,7 @@ int32_t uart_write_data(uint8_t *data, uint16_t size)
 
 int32_t uart_read_data(uint8_t *data, uint16_t size)
 {
-    uint32_t cnt;
-
-    if (size == 0) {
-        return 0;
-    }
-
-    cnt = 0;
-
-    while (size--) {
-        if (read_buffer.cnt_in != read_buffer.cnt_out) {
-            *data++ = read_buffer.data[read_buffer.idx_out++];
-            read_buffer.idx_out &= (BUFFER_SIZE - 1);
-            read_buffer.cnt_out++;
-            cnt++;
-        } else {
-            break;
-        }
-    }
-
-    return cnt;
+    return circ_buf_read(&read_buffer, data, size);
 }
 
 void UART1_RX_TX_IRQHandler(void)
@@ -245,13 +202,12 @@ void UART1_RX_TX_IRQHandler(void)
     // handle character to transmit
     if (s1 & UART_S1_TDRE_MASK) {
         // Assert that there is data in the buffer
-        util_assert(write_buffer.cnt_in != write_buffer.cnt_out);
+        util_assert(circ_buf_count_used(&write_buffer) > 0);
+
         // Send out data
-        UART1->D = write_buffer.data[write_buffer.idx_out++];
-        write_buffer.idx_out &= (BUFFER_SIZE - 1);
-        write_buffer.cnt_out++;
+        UART1->D = circ_buf_pop(&write_buffer);
         // Turn off the transmitter if that was the last byte
-        if (write_buffer.cnt_in == write_buffer.cnt_out) {
+        if (circ_buf_count_used(&write_buffer) == 0) {
             // disable TIE interrupt
             UART1->C2 &= ~(UART_C2_TIE_MASK);
         }
@@ -262,9 +218,18 @@ void UART1_RX_TX_IRQHandler(void)
         if ((s1 & UART_S1_NF_MASK) || (s1 & UART_S1_FE_MASK)) {
             errorData = UART1->D;
         } else {
-            read_buffer.data[read_buffer.idx_in++] = UART1->D;
-            read_buffer.idx_in &= (BUFFER_SIZE - 1);
-            read_buffer.cnt_in++;
+            uint32_t free;
+            uint8_t data;
+            
+            data = UART1->D;
+            free = circ_buf_count_free(&read_buffer);
+            if (free > RX_OVRF_MSG_SIZE) {
+                circ_buf_push(&read_buffer, data);
+            } else if (RX_OVRF_MSG_SIZE == free) {
+                circ_buf_write(&read_buffer, (uint8_t*)RX_OVRF_MSG, RX_OVRF_MSG_SIZE);
+            } else {
+                // Drop character
+            }
         }
     }
 }

--- a/source/hic_hal/freescale/k20dx/uart.c
+++ b/source/hic_hal/freescale/k20dx/uart.c
@@ -26,6 +26,7 @@
 #include "util.h"
 #include "cortex_m.h"
 #include "circ_buf.h"
+#include "settings.h" // for config_get_overflow_detect
 
 extern uint32_t SystemCoreClock;
 
@@ -225,7 +226,7 @@ void UART1_RX_TX_IRQHandler(void)
             free = circ_buf_count_free(&read_buffer);
             if (free > RX_OVRF_MSG_SIZE) {
                 circ_buf_push(&read_buffer, data);
-            } else if (RX_OVRF_MSG_SIZE == free) {
+            } else if ((RX_OVRF_MSG_SIZE == free) && config_get_overflow_detect()) {
                 circ_buf_write(&read_buffer, (uint8_t*)RX_OVRF_MSG, RX_OVRF_MSG_SIZE);
             } else {
                 // Drop character

--- a/source/hic_hal/freescale/kl26z/uart.c
+++ b/source/hic_hal/freescale/kl26z/uart.c
@@ -26,6 +26,7 @@
 #include "cortex_m.h"
 #include "IO_Config.h"
 #include "circ_buf.h"
+#include "settings.h" // for config_get_overflow_detect
 
 #define RX_OVRF_MSG         "<DAPLink:Overflow>\n"
 #define RX_OVRF_MSG_SIZE    (sizeof(RX_OVRF_MSG) - 1)
@@ -244,7 +245,7 @@ void UART_RX_TX_IRQHandler(void)
             free = circ_buf_count_free(&read_buffer);
             if (free > RX_OVRF_MSG_SIZE) {
                 circ_buf_push(&read_buffer, data);
-            } else if (RX_OVRF_MSG_SIZE == free) {
+            } else if ((RX_OVRF_MSG_SIZE == free) && config_get_overflow_detect()) {
                 circ_buf_write(&read_buffer, (uint8_t*)RX_OVRF_MSG, RX_OVRF_MSG_SIZE);
             } else {
                 // Drop character

--- a/source/hic_hal/freescale/kl26z/uart.c
+++ b/source/hic_hal/freescale/kl26z/uart.c
@@ -25,31 +25,22 @@
 #include "util.h"
 #include "cortex_m.h"
 #include "IO_Config.h"
+#include "circ_buf.h"
 
-// Size must be 2^n for using quick wrap around
-#define UART_BUFFER_SIZE (512)
+#define RX_OVRF_MSG         "<DAPLink:Overflow>\n"
+#define RX_OVRF_MSG_SIZE    (sizeof(RX_OVRF_MSG) - 1)
+#define BUFFER_SIZE         (512)
 
-struct {
-    uint8_t  data[UART_BUFFER_SIZE];
-    volatile uint32_t idx_in;
-    volatile uint32_t idx_out;
-    volatile uint32_t cnt_in;
-    volatile uint32_t cnt_out;
-} write_buffer, read_buffer;
+circ_buf_t write_buffer;
+uint8_t write_buffer_data[BUFFER_SIZE];
+circ_buf_t read_buffer;
+uint8_t read_buffer_data[BUFFER_SIZE];
 
 void clear_buffers(void)
 {
     util_assert(!(UART->C2 & UART_C2_TIE_MASK));
-    memset((void *)&read_buffer, 0xBB, sizeof(read_buffer.data));
-    read_buffer.idx_in = 0;
-    read_buffer.idx_out = 0;
-    read_buffer.cnt_in = 0;
-    read_buffer.cnt_out = 0;
-    memset((void *)&write_buffer, 0xBB, sizeof(read_buffer.data));
-    write_buffer.idx_in = 0;
-    write_buffer.idx_out = 0;
-    write_buffer.cnt_in = 0;
-    write_buffer.cnt_out = 0;
+    circ_buf_init(&write_buffer, write_buffer_data, sizeof(write_buffer_data));
+    circ_buf_init(&read_buffer, read_buffer_data, sizeof(read_buffer_data));
 }
 
 int32_t uart_initialize(void)
@@ -189,35 +180,19 @@ int32_t uart_get_configuration(UART_Configuration *config)
 
 int32_t uart_write_free(void)
 {
-    return UART_BUFFER_SIZE - (write_buffer.cnt_in - write_buffer.cnt_out);
+    return circ_buf_count_free(&write_buffer);
 }
 
 int32_t uart_write_data(uint8_t *data, uint16_t size)
 {
-    uint32_t cnt;
-    int16_t  len_in_buf;
     cortex_int_state_t state;
+    uint32_t cnt;
 
-    if (size == 0) {
-        return 0;
-    }
-
-    cnt = 0;
-
-    while (size--) {
-        len_in_buf = write_buffer.cnt_in - write_buffer.cnt_out;
-
-        if (len_in_buf < UART_BUFFER_SIZE) {
-            write_buffer.data[write_buffer.idx_in++] = *data++;
-            write_buffer.idx_in &= (UART_BUFFER_SIZE - 1);
-            write_buffer.cnt_in++;
-            cnt++;
-        }
-    }
+    cnt = circ_buf_write(&write_buffer, data, size);
 
     // Atomically enable TX
     state = cortex_int_get_and_disable();
-    if (write_buffer.cnt_in != write_buffer.cnt_out) {
+    if (circ_buf_count_used(&write_buffer)) {
         UART->C2 |= UART_C2_TIE_MASK;
     }
     cortex_int_restore(state);
@@ -227,26 +202,7 @@ int32_t uart_write_data(uint8_t *data, uint16_t size)
 
 int32_t uart_read_data(uint8_t *data, uint16_t size)
 {
-    uint32_t cnt;
-
-    if (size == 0) {
-        return 0;
-    }
-
-    cnt = 0;
-
-    while (size--) {
-        if (read_buffer.cnt_in != read_buffer.cnt_out) {
-            *data++ = read_buffer.data[read_buffer.idx_out++];
-            read_buffer.idx_out &= (UART_BUFFER_SIZE - 1);
-            read_buffer.cnt_out++;
-            cnt++;
-        } else {
-            break;
-        }
-    }
-
-    return cnt;
+    return circ_buf_read(&read_buffer, data, size);
 }
 
 void UART_RX_TX_IRQHandler(void)
@@ -266,13 +222,11 @@ void UART_RX_TX_IRQHandler(void)
     // handle character to transmit
     if (s1 & UART_S1_TDRE_MASK) {
         // Assert that there is data in the buffer
-        util_assert(write_buffer.cnt_in != write_buffer.cnt_out);
+        util_assert(circ_buf_count_used(&write_buffer) > 0);
         // Send out data
-        UART->D = write_buffer.data[write_buffer.idx_out++];
-        write_buffer.idx_out &= (UART_BUFFER_SIZE - 1);
-        write_buffer.cnt_out++;
+        UART1->D = circ_buf_pop(&write_buffer);
         // Turn off the transmitter if that was the last byte
-        if (write_buffer.cnt_in == write_buffer.cnt_out) {
+        if (circ_buf_count_used(&write_buffer) == 0) {
             // disable TIE interrupt
             UART->C2 &= ~(UART_C2_TIE_MASK);
         }
@@ -283,9 +237,18 @@ void UART_RX_TX_IRQHandler(void)
         if ((s1 & UART_S1_NF_MASK) || (s1 & UART_S1_FE_MASK)) {
             errorData = UART->D;
         } else {
-            read_buffer.data[read_buffer.idx_in++] = UART->D;
-            read_buffer.idx_in &= (UART_BUFFER_SIZE - 1);
-            read_buffer.cnt_in++;
+            uint32_t free;
+            uint8_t data;
+            
+            data = UART1->D;
+            free = circ_buf_count_free(&read_buffer);
+            if (free > RX_OVRF_MSG_SIZE) {
+                circ_buf_push(&read_buffer, data);
+            } else if (RX_OVRF_MSG_SIZE == free) {
+                circ_buf_write(&read_buffer, (uint8_t*)RX_OVRF_MSG, RX_OVRF_MSG_SIZE);
+            } else {
+                // Drop character
+            }
         }
     }
 }

--- a/source/hic_hal/nxp/lpc11u35/uart.c
+++ b/source/hic_hal/nxp/lpc11u35/uart.c
@@ -23,6 +23,7 @@
 #include "uart.h"
 #include "util.h"
 #include "circ_buf.h"
+#include "settings.h" // for config_get_overflow_detect
 
 static uint32_t baudrate;
 static uint32_t dll;
@@ -312,7 +313,7 @@ void UART_IRQHandler(void)
             free = circ_buf_count_free(&read_buffer);
             if (free > RX_OVRF_MSG_SIZE) {
                 circ_buf_push(&read_buffer, data);
-            } else if (RX_OVRF_MSG_SIZE == free) {
+            } else if ((RX_OVRF_MSG_SIZE == free) && config_get_overflow_detect()) {
                 circ_buf_write(&read_buffer, (uint8_t*)RX_OVRF_MSG, RX_OVRF_MSG_SIZE);
             } else {
                 // Drop character

--- a/source/hic_hal/nxp/lpc11u35/uart.c
+++ b/source/hic_hal/nxp/lpc11u35/uart.c
@@ -22,6 +22,7 @@
 #include "LPC11Uxx.h"
 #include "uart.h"
 #include "util.h"
+#include "circ_buf.h"
 
 static uint32_t baudrate;
 static uint32_t dll;
@@ -29,16 +30,14 @@ static uint32_t tx_in_progress;
 
 extern uint32_t SystemCoreClock;
 
-// Size must be 2^n
-#define  BUFFER_SIZE (64)
+#define RX_OVRF_MSG         "<DAPLink:Overflow>\n"
+#define RX_OVRF_MSG_SIZE    (sizeof(RX_OVRF_MSG) - 1)
+#define BUFFER_SIZE         (64)
 
-static struct {
-    uint8_t  data[BUFFER_SIZE];
-    volatile uint16_t idx_in;
-    volatile uint16_t idx_out;
-    volatile  int16_t cnt_in;
-    volatile  int16_t cnt_out;
-} write_buffer, read_buffer;
+circ_buf_t write_buffer;
+uint8_t write_buffer_data[BUFFER_SIZE];
+circ_buf_t read_buffer;
+uint8_t read_buffer_data[BUFFER_SIZE];
 
 static int32_t reset(void);
 
@@ -255,30 +254,14 @@ int32_t uart_get_configuration(UART_Configuration *config)
 
 int32_t uart_write_free(void)
 {
-    return BUFFER_SIZE - (write_buffer.cnt_in - write_buffer.cnt_out);
+    return circ_buf_count_free(&write_buffer);
 }
 
 int32_t uart_write_data(uint8_t *data, uint16_t size)
 {
     uint32_t cnt;
-    int16_t  len_in_buf;
 
-    if (size == 0) {
-        return 0;
-    }
-
-    cnt = 0;
-
-    while (size--) {
-        len_in_buf = write_buffer.cnt_in - write_buffer.cnt_out;
-
-        if (len_in_buf < BUFFER_SIZE) {
-            write_buffer.data[write_buffer.idx_in++] = *data++;
-            write_buffer.idx_in &= (BUFFER_SIZE - 1);
-            write_buffer.cnt_in++;
-            cnt++;
-        }
-    }
+    cnt = circ_buf_write(&write_buffer, data, size);
 
     // enable THRE interrupt
     LPC_USART->IER |= (1 << 1);
@@ -294,41 +277,21 @@ int32_t uart_write_data(uint8_t *data, uint16_t size)
 
 int32_t uart_read_data(uint8_t *data, uint16_t size)
 {
-    uint32_t cnt;
-
-    if (size == 0) {
-        return 0;
-    }
-
-    cnt = 0;
-
-    while (size--) {
-        if (read_buffer.cnt_in != read_buffer.cnt_out) {
-            *data++ = read_buffer.data[read_buffer.idx_out++];
-            read_buffer.idx_out &= (BUFFER_SIZE - 1);
-            read_buffer.cnt_out++;
-            cnt++;
-        }
-    }
-
-    return cnt;
+    return circ_buf_read(&read_buffer, data, size);
 }
 
 
 void UART_IRQHandler(void)
 {
     uint32_t iir;
-    int16_t  len_in_buf;
     // read interrupt status
     iir = LPC_USART->IIR;
 
     // handle character to transmit
-    if (write_buffer.cnt_in != write_buffer.cnt_out) {
+    if (circ_buf_count_used(&write_buffer) > 0) {
         // if THR is empty
         if (LPC_USART->LSR & (1 << 5)) {
-            LPC_USART->THR = write_buffer.data[write_buffer.idx_out++];
-            write_buffer.idx_out &= (BUFFER_SIZE - 1);
-            write_buffer.cnt_out++;
+            LPC_USART->THR = circ_buf_pop(&write_buffer);
             tx_in_progress = 1;
         }
 
@@ -342,16 +305,17 @@ void UART_IRQHandler(void)
     if (((iir & 0x0E) == 0x04)  ||        // Rx interrupt (RDA)
             ((iir & 0x0E) == 0x0C))  {        // Rx interrupt (CTI)
         while (LPC_USART->LSR & 0x01) {
-            len_in_buf = read_buffer.cnt_in - read_buffer.cnt_out;
-            read_buffer.data[read_buffer.idx_in++] = LPC_USART->RBR;
-            read_buffer.idx_in &= (BUFFER_SIZE - 1);
-            read_buffer.cnt_in++;
-
-            // if buffer full: write by dropping oldest characters
-            if (len_in_buf == BUFFER_SIZE) {
-                read_buffer.idx_out++;
-                read_buffer.idx_out &= (BUFFER_SIZE - 1);
-                read_buffer.cnt_out++;
+            uint32_t free;
+            uint8_t data;
+            
+            data = LPC_USART->RBR;
+            free = circ_buf_count_free(&read_buffer);
+            if (free > RX_OVRF_MSG_SIZE) {
+                circ_buf_push(&read_buffer, data);
+            } else if (RX_OVRF_MSG_SIZE == free) {
+                circ_buf_write(&read_buffer, (uint8_t*)RX_OVRF_MSG, RX_OVRF_MSG_SIZE);
+            } else {
+                // Drop character
             }
         }
     }
@@ -361,25 +325,14 @@ void UART_IRQHandler(void)
 
 static int32_t reset(void)
 {
-    uint8_t *ptr;
-    int32_t  i;
-
     // Reset FIFOs
     LPC_USART->FCR = 0x06;
     baudrate  = 0;
     dll       = 0;
     tx_in_progress = 0;
-    ptr = (uint8_t *)&write_buffer;
 
-    for (i = 0; i < sizeof(write_buffer); i++) {
-        *ptr++ = 0;
-    }
-
-    ptr = (uint8_t *)&read_buffer;
-
-    for (i = 0; i < sizeof(read_buffer); i++) {
-        *ptr++ = 0;
-    }
+    circ_buf_init(&write_buffer, write_buffer_data, sizeof(write_buffer_data));
+    circ_buf_init(&read_buffer, read_buffer_data, sizeof(read_buffer_data));
 
     // Ensure a clean start, no data in either TX or RX FIFO
     while ((LPC_USART->LSR & ((1 << 5) | (1 << 6))) != ((1 << 5) | (1 << 6)));

--- a/tools/generate_config.py
+++ b/tools/generate_config.py
@@ -27,17 +27,19 @@ CFG_KEY = 0x6b766c64
 # 16 - offset_of_end
 # 8  - auto_rst
 # 8  - automation_allowed
+# 8  - overflow_detect
 # 0  - 'end' member omitted
-FORMAT = '<LHBB'
+FORMAT = '<LHBBB'
 FORMAT_LENGTH = struct.calcsize(FORMAT)
 MINIMUM_ALIGN = 1 << 10  # 1k aligned
 
 
-def create_hex(filename, addr, auto_rst, automation_allowed, pad_size):
+def create_hex(filename, addr, auto_rst, automation_allowed,
+               overflow_detect, pad_size):
     file_format = 'hex'
     intel_hex = IntelHex()
     intel_hex.puts(addr, struct.pack(FORMAT, CFG_KEY, FORMAT_LENGTH, auto_rst,
-                                     automation_allowed))
+                                     automation_allowed, overflow_detect))
     pad_addr = addr + FORMAT_LENGTH
     pad_byte_count = pad_size - (FORMAT_LENGTH % pad_size)
     pad_data = '\xFF' * pad_byte_count
@@ -55,6 +57,7 @@ parser = argparse.ArgumentParser(description='Configuration Creator')
 parser.add_argument("--addr", type=str_to_int, required=True, help="Address of configuration data")
 parser.add_argument("--auto_rst", type=int, required=True, choices=[0, 1], help="Auto reset configuration value")
 parser.add_argument("--automation_allowed", type=int, required=True, choices=[0,1], help="Allow automation from filesystem interaction")
+parser.add_argument("--overflow_detect", type=int, required=True, choices=[0,1], help="Enable detection of UART overflow")
 parser.add_argument("--pad", type=int, default=16, choices=POWERS_OF_TWO, metavar="{1, 2, 4,...}", help="Byte aligned boundary to pad region to")
 parser.add_argument("--output_file", type=str, default='settings.hex', help="Name of output file")
 
@@ -69,9 +72,11 @@ def main():
         print "WARNING! Configuration is not aligned to pad size"
     print "Settings:"
     print "  auto_rst: %i" % args.auto_rst
+    print "  automation_allowed: %i" % args.automation_allowed
+    print "  overflow_detect: %i" % args.overflow_detect
     print ""
     create_hex(args.output_file, args.addr, args.auto_rst,
-               args.automation_allowed, args.pad)
+               args.automation_allowed, args.overflow_detect, args.pad)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Update all uart drivers to use a common queue driver for TX and RX. Update overflow behavior so once DAPLink's RX buffer has filled further characters are dropped. Also add the message "<OVFL>" to the
serial data if an overflow condition occurs.
