### PR TITLE
Allow automated tests to recover from interrupted interface load

### DIFF
--- a/source/daplink/RTX_Config.c
+++ b/source/daplink/RTX_Config.c
@@ -21,7 +21,6 @@
 
 #include "RTL.h"
 #include "util.h"
-#include "IO_Config.h" // NVIC_SystemReset
 
 /*----------------------------------------------------------------------------
  *      RTX User configuration part BEGIN
@@ -208,7 +207,7 @@ void os_error(U32 err_code)
             break;
     }
 
-    NVIC_SystemReset();
+    util_reset_to_mode(RESET_MODE_ERR);
 
     for (;;); // Wait for reset
 }

--- a/source/daplink/interface/main.c
+++ b/source/daplink/interface/main.c
@@ -164,10 +164,7 @@ void USBD_SignalHandler()
 
 void HardFault_Handler()
 {
-    util_assert(0);
-    NVIC_SystemReset();
-
-    while (1); // Wait for reset
+    util_reset_to_mode(RESET_MODE_ERR);
 }
 
 os_mbx_declare(serial_mailbox, 20);

--- a/source/daplink/settings/settings.h
+++ b/source/daplink/settings/settings.h
@@ -34,6 +34,17 @@ typedef enum {
     ASSERT_SOURCE_APP = 2
 } assert_source_t;
 
+typedef enum {
+    // Reset to interface mode
+    RESET_MODE_IF = 0,
+    // Reset to bootloader mode
+    RESET_MODE_BL = 1,
+    // Reset to error handling mode
+    RESET_MODE_ERR = 2,
+    // No mode specified
+    RESET_MODE_NONE = 3
+} reset_mode_t;
+
 void config_init(void);
 
 // Get/set settings residing in flash
@@ -43,11 +54,10 @@ bool config_get_auto_rst(void);
 bool config_get_automation_allowed(void);
 
 // Get/set settings residing in shared ram
-void config_ram_set_hold_in_bl(bool hold);
+void config_ram_set_reset_mode(reset_mode_t mode);
 void config_ram_set_assert(const char *file, uint16_t line);
 void config_ram_clear_assert(void);
-bool config_ram_get_hold_in_bl(void);
-bool config_ram_get_initial_hold_in_bl(void);
+reset_mode_t config_ram_get_reset_mode(void);
 bool config_ram_get_assert(char *buf, uint16_t buf_size, uint16_t *line, assert_source_t *source);
 
 // Private - should only be called from settings.c

--- a/source/daplink/util.c
+++ b/source/daplink/util.c
@@ -157,3 +157,10 @@ void util_assert_clear()
     config_ram_clear_assert();
     cortex_int_restore(int_state);
 }
+
+void util_reset_to_mode(reset_mode_t mode)
+{
+    config_ram_set_reset_mode(mode);
+    NVIC_SystemReset();
+    while (1); // Wait for reset
+}

--- a/source/daplink/util.h
+++ b/source/daplink/util.h
@@ -24,6 +24,7 @@
 
 #include "stdbool.h"
 #include "stdint.h"
+#include "settings.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -52,6 +53,7 @@ uint32_t util_div_round(uint32_t dividen, uint32_t divisor);
 void _util_assert(bool expression, const char *filename, uint16_t line);
 
 void util_assert_clear(void);
+void util_reset_to_mode(reset_mode_t mode);
 
 #ifdef __cplusplus
 }

--- a/source/hic_hal/nxp/lpc11u35/gpio.c
+++ b/source/hic_hal/nxp/lpc11u35/gpio.c
@@ -112,7 +112,7 @@ void gpio_init(void)
     // Give the cap on the reset button time to charge
     busy_wait(10000);
 
-    if ((gpio_get_sw_reset() == 0) || config_ram_get_initial_hold_in_bl()) {
+    if ((gpio_get_sw_reset() == 0) || (config_ram_get_reset_mode() == RESET_MODE_BL)) {
         IRQn_Type irq;
         // Disable SYSTICK timer and interrupt before calling into ISP
         SysTick->CTRL &= ~(SysTick_CTRL_ENABLE_Msk | SysTick_CTRL_TICKINT_Msk);
@@ -125,7 +125,7 @@ void gpio_init(void)
 
         // If switching to "bootloader" mode then setup the watchdog
         // so it will exit CRP mode after ~30 seconds
-        if (config_ram_get_initial_hold_in_bl()) {
+        if (config_ram_get_reset_mode() == RESET_MODE_BL) {
             LPC_SYSCON->SYSAHBCLKCTRL |= (1 << 15); // Enable watchdog module
             LPC_SYSCON->PDRUNCFG &= ~(1 << 6);      // Enable watchdog clock (WDOSC)
             LPC_SYSCON->WDTOSCCTRL = (0xF << 5);    // Set max frequency - 2.3MHz


### PR DESCRIPTION
Hold DAPLink in bootloader mode if the interface firmware crashes. This prevents devices from getting stuck in a crash loop and allows boards to be recovered during automated testing. This patch also updates the tests to ensure that even if an error occurs, the test will finish with a valid interface and bootloader.