### PR TITLE
Synchronize hid by moving it to main thread

### DIFF
--- a/source/daplink/cmsis-dap/usbd_user_hid.c
+++ b/source/daplink/cmsis-dap/usbd_user_hid.c
@@ -27,6 +27,7 @@
 #include "usb_config.c"
 #include "DAP_config.h"
 #include "DAP.h"
+#include "util.h"
 
 #include "main.h"
 
@@ -130,6 +131,8 @@ void usbd_hid_set_report(U8 rtype, U8 rid, U8 *buf, int len, U8 req)
                 memcpy(USB_Request[recv_idx], buf, len);
                 recv_idx = (recv_idx + 1) % DAP_PACKET_COUNT;
                 os_sem_send(&proc_sem);
+            } else {
+                util_assert(0);
             }
 
             break;

--- a/source/daplink/interface/main.h
+++ b/source/daplink/interface/main.h
@@ -55,6 +55,7 @@ void main_usb_configure_event(void);
 void main_usb_busy_event(void);
 void main_powerdown_event(void);
 void main_disable_debug_event(void);
+void main_hid_send_event(void);
 void main_msc_disconnect_event(void);
 void main_msc_delay_disconnect_event(void);
 void main_force_msc_disconnect_event(void);


### PR DESCRIPTION
Move the HID response to the main thread. This ensures that all HID USB operations are done on the same thread.
 