### PR TITLE
Update led code to match hardware

### DIFF
--- a/source/daplink/interface/main.c
+++ b/source/daplink/interface/main.c
@@ -260,9 +260,9 @@ __task void main_task(void)
     // State processing
     uint16_t flags = 0;
     // LED
-    gpio_led_state_t hid_led_value = GPIO_LED_ON;
-    gpio_led_state_t cdc_led_value = GPIO_LED_ON;
-    gpio_led_state_t msc_led_value = GPIO_LED_ON;
+    gpio_led_state_t hid_led_value = GPIO_LED_OFF;
+    gpio_led_state_t cdc_led_value = GPIO_LED_OFF;
+    gpio_led_state_t msc_led_value = GPIO_LED_OFF;
     // USB
     uint32_t usb_state_count = USB_BUSY_TIME;
     // thread running after usb connected started
@@ -409,48 +409,45 @@ __task void main_task(void)
                     break;
             }
 
+            // DAP LED
             if (hid_led_usb_activity && ((hid_led_state == MAIN_LED_FLASH) || (hid_led_state == MAIN_LED_FLASH_PERMANENT))) {
-                // Flash DAP LED ONCE
-                if (hid_led_value) {
-                    hid_led_value = GPIO_LED_OFF;
-                } else {
-                    hid_led_value = GPIO_LED_ON; // Turn on
 
-                    if (hid_led_state == MAIN_LED_FLASH) {
-                        hid_led_usb_activity = 0;
-                    }
+                // Toggle LED value
+                hid_led_value = GPIO_LED_ON == hid_led_value ? GPIO_LED_OFF : GPIO_LED_ON;
+
+                // If in flash mode stop after one cycle
+                if ((GPIO_LED_OFF == hid_led_value) && (MAIN_LED_FLASH == hid_led_state)) {
+                    hid_led_usb_activity = 0;
                 }
 
                 // Update hardware
                 gpio_set_hid_led(hid_led_value);
             }
 
+            // MSD LED
             if (msc_led_usb_activity && ((msc_led_state == MAIN_LED_FLASH) || (msc_led_state == MAIN_LED_FLASH_PERMANENT))) {
-                // Flash MSD LED ONCE
-                if (msc_led_value) {
-                    msc_led_value = GPIO_LED_OFF;
-                } else {
-                    msc_led_value = GPIO_LED_ON; // Turn on
 
-                    if (msc_led_state == MAIN_LED_FLASH) {
-                        msc_led_usb_activity = 0;
-                    }
+                // Toggle LED value
+                msc_led_value = GPIO_LED_ON == msc_led_value ? GPIO_LED_OFF : GPIO_LED_ON;
+
+                // If in flash mode stop after one cycle
+                if ((GPIO_LED_OFF == msc_led_value) && (MAIN_LED_FLASH == msc_led_state)) {
+                    msc_led_usb_activity = 0;
                 }
 
                 // Update hardware
                 gpio_set_msc_led(msc_led_value);
             }
 
+            // CDC LED
             if (cdc_led_usb_activity && ((cdc_led_state == MAIN_LED_FLASH) || (cdc_led_state == MAIN_LED_FLASH_PERMANENT))) {
-                // Flash CDC LED ONCE
-                if (cdc_led_value) {
-                    cdc_led_value = GPIO_LED_OFF;
-                } else {
-                    cdc_led_value = GPIO_LED_ON; // Turn on
 
-                    if (cdc_led_state == MAIN_LED_FLASH) {
-                        cdc_led_usb_activity = 0;
-                    }
+                // Toggle LED value
+                cdc_led_value = GPIO_LED_ON == cdc_led_value ? GPIO_LED_OFF : GPIO_LED_ON;
+
+                // If in flash mode stop after one cycle
+                if ((GPIO_LED_OFF == cdc_led_value) && (MAIN_LED_FLASH == cdc_led_state)) {
+                    cdc_led_usb_activity = 0;
                 }
 
                 // Update hardware

--- a/source/hic_hal/nxp/lpc11u35/gpio.c
+++ b/source/hic_hal/nxp/lpc11u35/gpio.c
@@ -162,27 +162,27 @@ void gpio_init(void)
 void gpio_set_hid_led(gpio_led_state_t state)
 {
     if (state) {
-        LPC_GPIO->SET[PIN_DAP_LED_PORT] = PIN_DAP_LED;
-    } else {
         LPC_GPIO->CLR[PIN_DAP_LED_PORT] = PIN_DAP_LED;
+    } else {
+        LPC_GPIO->SET[PIN_DAP_LED_PORT] = PIN_DAP_LED;
     }
 }
 
 void gpio_set_cdc_led(gpio_led_state_t state)
 {
     if (state) {
-        LPC_GPIO->SET[PIN_CDC_LED_PORT] = PIN_CDC_LED;
-    } else {
         LPC_GPIO->CLR[PIN_CDC_LED_PORT] = PIN_CDC_LED;
+    } else {
+        LPC_GPIO->SET[PIN_CDC_LED_PORT] = PIN_CDC_LED;
     }
 }
 
 void gpio_set_msc_led(gpio_led_state_t state)
 {
     if (state) {
-        LPC_GPIO->SET[PIN_MSD_LED_PORT] = PIN_MSD_LED;
-    } else {
         LPC_GPIO->CLR[PIN_MSD_LED_PORT] = PIN_MSD_LED;
+    } else {
+        LPC_GPIO->SET[PIN_MSD_LED_PORT] = PIN_MSD_LED;
     }
 }
 


### PR DESCRIPTION
Update the lpc11u35's led driver so GPIO_LED_ON corresponds to an led that is turned on.  Update main.c so when there is no endpoint activity the endpoint LED defaults to off rather than on.