### PR TITLE
Revert "Added swd_uninit_debug() function. Used new function in reset…"

### DIFF
--- a/source/daplink/interface/swd_host.c
+++ b/source/daplink/interface/swd_host.c
@@ -831,25 +831,6 @@ uint8_t swd_init_debug(void)
     return 1;
 }
 
-uint8_t swd_uninit_debug(void)
-{
-    // Assume debug is powered up already
-    // Clear (CSYSPWRUPREQ | CDBGPWRUPREQ) in DP_CTRL_STAT register
-    uint32_t ctrl_stat_read;
-
-    if (!swd_write_dp(DP_CTRL_STAT, 0x0)) {
-        return 0;
-    }
-
-    do {
-        if (!swd_read_dp(DP_CTRL_STAT, &ctrl_stat_read)) {
-            return 0;
-        }
-    } while ((ctrl_stat_read & (CSYSPWRUPREQ | CDBGPWRUPREQ)));
-
-    return 1;
-}
-
 __attribute__((weak)) void swd_set_target_reset(uint8_t asserted)
 {
     (asserted) ? PIN_nRESET_OUT(0) : PIN_nRESET_OUT(1);

--- a/source/daplink/interface/swd_host.h
+++ b/source/daplink/interface/swd_host.h
@@ -37,7 +37,6 @@ extern "C" {
 uint8_t swd_init(void);
 uint8_t swd_off(void);
 uint8_t swd_init_debug(void);
-uint8_t swd_uninit_debug(void);
 uint8_t swd_read_dp(uint8_t adr, uint32_t *val);
 uint8_t swd_write_dp(uint8_t adr, uint32_t val);
 uint8_t swd_read_ap(uint32_t adr, uint32_t *val);

--- a/source/daplink/interface/target_flash.c
+++ b/source/daplink/interface/target_flash.c
@@ -79,7 +79,6 @@ static error_t target_flash_uninit(void)
         target_set_state(RESET_RUN);
     }
 
-    swd_uninit_debug();
     swd_off();
     return ERROR_SUCCESS;
 }

--- a/source/target/nordic/target_reset_nrf5x_sam3u2c.c
+++ b/source/target/nordic/target_reset_nrf5x_sam3u2c.c
@@ -70,11 +70,8 @@ void swd_set_target_reset(uint8_t asserted)
                 swd_write_memory(0xE000ED0C, (uint8_t *)&swd_mem_write_data, 4);
                 //os_dly_wait(1);
             }
-            swd_uninit_debug();
         }
-        else {
-            swd_init_debug();
-            
+        else {           
             swd_read_ap(0x010000FC, &ap_index_return);
             if (ap_index_return == 0x02880000) {
                 // Device has CTRL-AP
@@ -83,7 +80,7 @@ void swd_set_target_reset(uint8_t asserted)
             else {
                 // No CTRL-AP - Soft reset has been performed
             }
-            swd_uninit_debug();
+            PIOA->PIO_MDER = PIN_SWDIO | PIN_SWCLK | PIN_nRESET;
         }
     }
     else {


### PR DESCRIPTION
This reverts commit c074a58052873296fa9f918341cb0e06e6ab0c03. This is reverted because it causes some lpc targets such as the lpc812 to enter a bad state after programming, since the DP is turned off while the debug logic is still enabled.