### PR TITLE
Fix release package script to handle underscores

### DIFF
--- a/tools/package_release_files.py
+++ b/tools/package_release_files.py
@@ -50,7 +50,7 @@ def main():
         items = prj_name.split('_')  # "k20dx_frdmk22f_if" -> ("k20dx", "frdmk22f", "if")
         assert items[-1] == "if", "Unexpected string: %s" % items[2]
         host_mcu = items[0]
-        base_name = items[1]
+        base_name = '_'.join(items[1:-1])
         dest_offset_str = "_0x%04x" % offset
         dest_name = build_number + "_" + host_mcu + "_" + base_name + dest_offset_str + "." + extension
         dest_path = os.path.join(output_dir, dest_name)


### PR DESCRIPTION
The package release script incorrectly handles underscores in the base name of firmware. Instead of getting the whole name it only grabs up to the first underscore. For example for the base name of 'sam3u2c_mkit_dk_dongle_nrf5x_if' is determined to be 'mkit' rather than 'mkit_dk_dongle_nrf5x'. This patch fixes that problem by joining the middle elements of the name to create the correct base name.