### PR TITLE
Drop oldest character on UART overflow

### DIFF
--- a/source/hic_hal/atmel/sam3u2c/uart.c
+++ b/source/hic_hal/atmel/sam3u2c/uart.c
@@ -395,10 +395,16 @@ void UART_IRQHandler(void)
         cnt = (int32_t)circ_buf_count_free(&read_buffer) - RX_OVRF_MSG_SIZE;
         if (cnt > 0) {
             circ_buf_push(&read_buffer, data);
-        } else if ((0 == cnt) && config_get_overflow_detect()) {
-            circ_buf_write(&read_buffer, (uint8_t*)RX_OVRF_MSG, RX_OVRF_MSG_SIZE);
+        } else if (config_get_overflow_detect()) {
+            if (0 == cnt) {
+                circ_buf_write(&read_buffer, (uint8_t*)RX_OVRF_MSG, RX_OVRF_MSG_SIZE);
+            } else {
+                // Drop newest
+            }
         } else {
-            // Drop character
+            // Drop oldest
+            circ_buf_pop(&read_buffer);
+            circ_buf_push(&read_buffer, data);
         }
 
         //If this was the last available byte on the buffer then assert RTS

--- a/source/hic_hal/freescale/k20dx/uart.c
+++ b/source/hic_hal/freescale/k20dx/uart.c
@@ -226,10 +226,16 @@ void UART1_RX_TX_IRQHandler(void)
             free = circ_buf_count_free(&read_buffer);
             if (free > RX_OVRF_MSG_SIZE) {
                 circ_buf_push(&read_buffer, data);
-            } else if ((RX_OVRF_MSG_SIZE == free) && config_get_overflow_detect()) {
-                circ_buf_write(&read_buffer, (uint8_t*)RX_OVRF_MSG, RX_OVRF_MSG_SIZE);
+            } else if (config_get_overflow_detect()) {
+                if (RX_OVRF_MSG_SIZE == free) {
+                    circ_buf_write(&read_buffer, (uint8_t*)RX_OVRF_MSG, RX_OVRF_MSG_SIZE);
+                } else {
+                    // Drop newest
+                }
             } else {
-                // Drop character
+                // Drop oldest
+                circ_buf_pop(&read_buffer);
+                circ_buf_push(&read_buffer, data);
             }
         }
     }

--- a/source/hic_hal/freescale/kl26z/uart.c
+++ b/source/hic_hal/freescale/kl26z/uart.c
@@ -245,10 +245,16 @@ void UART_RX_TX_IRQHandler(void)
             free = circ_buf_count_free(&read_buffer);
             if (free > RX_OVRF_MSG_SIZE) {
                 circ_buf_push(&read_buffer, data);
-            } else if ((RX_OVRF_MSG_SIZE == free) && config_get_overflow_detect()) {
-                circ_buf_write(&read_buffer, (uint8_t*)RX_OVRF_MSG, RX_OVRF_MSG_SIZE);
+            } else if (config_get_overflow_detect()) {
+                if (RX_OVRF_MSG_SIZE == free) {
+                    circ_buf_write(&read_buffer, (uint8_t*)RX_OVRF_MSG, RX_OVRF_MSG_SIZE);
+                } else {
+                    // Drop newest
+                }
             } else {
-                // Drop character
+                // Drop oldest
+                circ_buf_pop(&read_buffer);
+                circ_buf_push(&read_buffer, data);
             }
         }
     }

--- a/source/hic_hal/nxp/lpc11u35/uart.c
+++ b/source/hic_hal/nxp/lpc11u35/uart.c
@@ -313,10 +313,16 @@ void UART_IRQHandler(void)
             free = circ_buf_count_free(&read_buffer);
             if (free > RX_OVRF_MSG_SIZE) {
                 circ_buf_push(&read_buffer, data);
-            } else if ((RX_OVRF_MSG_SIZE == free) && config_get_overflow_detect()) {
-                circ_buf_write(&read_buffer, (uint8_t*)RX_OVRF_MSG, RX_OVRF_MSG_SIZE);
+            } else if (config_get_overflow_detect()) {
+                if (RX_OVRF_MSG_SIZE == free) {
+                    circ_buf_write(&read_buffer, (uint8_t*)RX_OVRF_MSG, RX_OVRF_MSG_SIZE);
+                } else {
+                    // Drop newest
+                }
             } else {
-                // Drop character
+                // Drop oldest
+                circ_buf_pop(&read_buffer);
+                circ_buf_push(&read_buffer, data);
             }
         }
     }


### PR DESCRIPTION
When overflow detection is not turned on and and overflow occurs drop the oldest rather than the newest data. Newest data is still dropped if overflow detection is turned on.