### PR TITLE
Add retry logic to mass storage test

### DIFF
--- a/test/test_info.py
+++ b/test/test_info.py
@@ -121,6 +121,10 @@ class TestInfo(object):
         self._add_entry(self.SUBTEST, test_info)
         return test_info
 
+    def attach_subtest(self, subtest):
+        assert isinstance(subtest, TestInfo)
+        self._add_entry(self.SUBTEST, subtest)
+
     def get_counts(self):
         """
         Return the number of events that occured


### PR DESCRIPTION
Under certain conditions a PC running DAPLink tests can clear the disk cache DAPLink is mounted on. When this occurs the host OS will re-read disk contents. Since DAPLink's disk contents never change the
drive will look like it did when it first mounted. None of the new files that were created will exist. If this cache clear occurs in the middle of a write operation in the mass storage test an IOError will be raised, causing testing to terminate abruptly.

To prevent testing from spuriously failing this patch adds retry logic to the mass storage test. This prevents these spurious failures.

Note - a disk cache clear can be triggered by allocating most of the systems memory in a program. For example on a windows 10 PC with 16GB of RAM running the following code (which allocates 15GB) in a python terminal will typically trigger a cache clear of all disks:
"a = bytearray(1024 * 1024 * 1024 * 15)"