### PR TITLE
Atsam3u clock fix

### DIFF
--- a/source/daplink/cmsis-dap/DAP.c
+++ b/source/daplink/cmsis-dap/DAP.c
@@ -42,17 +42,11 @@
 
  // Clock Macros
 
-#if defined(INTERFACE_SAM3U2C)
-  #define MAX_SWJ_CLOCK(delay_cycles) \
-    (CPU_CLOCK / ((delay_cycles + IO_PORT_WRITE_CYCLES) * 20/*14*/))
-  #define CLOCK_DELAY(swj_clock) \
-    ((CPU_CLOCK / (swj_clock * /*20*/14)) - IO_PORT_WRITE_CYCLES)
-#else
-  #define MAX_SWJ_CLOCK(delay_cycles) \
-    (CPU_CLOCK/2 / (IO_PORT_WRITE_CYCLES + delay_cycles))
-  #define CLOCK_DELAY(swj_clock) \
-    ((CPU_CLOCK/2 / swj_clock) - IO_PORT_WRITE_CYCLES)
-#endif
+#define MAX_SWJ_CLOCK(delay_cycles) \
+  (CPU_CLOCK/2 / (IO_PORT_WRITE_CYCLES + delay_cycles))
+
+#define CLOCK_DELAY(swj_clock) \
+  ((CPU_CLOCK/2 / swj_clock) - IO_PORT_WRITE_CYCLES)
 
 
          DAP_Data_t DAP_Data;           // DAP Data

--- a/source/hic_hal/atmel/sam3u2c/read_uid.c
+++ b/source/hic_hal/atmel/sam3u2c/read_uid.c
@@ -60,5 +60,6 @@ void create_unique_id(void)
     /*Monitor FRDY*/
     while ((EFC0->EEFC_FSR & EEFC_FSR_FRDY) != EEFC_FSR_FRDY);
 
+    EFC0->EEFC_FMR &= ~(1UL << 16);
     cortex_int_restore(state);
 }


### PR DESCRIPTION
Fix incorrect flash settings causing core to run at 1/4th normal speed. Remove SWJ clock customizations since the core is running at the correct speed.