### PR TITLE
Pyusb testing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ requests
 intelhex
 six
 enum34
+pyusb

--- a/source/daplink/cmsis-dap/dap_vendor_command.c
+++ b/source/daplink/cmsis-dap/dap_vendor_command.c
@@ -28,6 +28,7 @@
 #include "DAP_config.h"
 #include "uart.h"
 #include "DAP.h"
+#include "main.h"
 
 // Process DAP Vendor command and prepare response
 // Default function (can be overridden)
@@ -45,6 +46,16 @@ uint32_t DAP_ProcessVendorCommand(uint8_t *request, uint8_t *response)
         *(response + 1) = len;
         memcpy(response + 2, id_str, len);
         return (len + 2);
+    } else if (*request == ID_DAP_Vendor8) {
+        *response = ID_DAP_Vendor8;
+        *(response + 1) = 1;
+        if (0 == request[1]) {
+            main_usb_set_test_mode(false);
+        } else if (1 == request[1]) {
+            main_usb_set_test_mode(true);
+        } else {
+            *(response + 1) = 0;
+        }
     }
     // else return invalid command
     else {

--- a/source/daplink/interface/main.c
+++ b/source/daplink/interface/main.c
@@ -78,6 +78,7 @@ static main_led_state_t msc_led_state = MAIN_LED_FLASH;
 
 // Global state of usb
 main_usb_connect_t usb_state;
+static bool usb_test_mode = false;
 
 static U64 stk_timer_30_task[TIMER_TASK_30_STACK / sizeof(U64)];
 static U64 stk_dap_task[DAP_TASK_STACK / sizeof(U64)];
@@ -172,6 +173,11 @@ void main_cdc_send_event(void)
     return;
 }
 
+void main_usb_set_test_mode(bool enabled)
+{
+    usb_test_mode = enabled;
+}
+
 void USBD_SignalHandler()
 {
     isr_evt_set(FLAGS_MAIN_PROC_USB, main_task_id);
@@ -245,6 +251,11 @@ __task void main_task(void)
         flags = os_evt_get();
 
         if (flags & FLAGS_MAIN_PROC_USB) {
+            if (usb_test_mode) {
+                // When in USB test mode Insert a delay to
+                // simulate worst-case behavior.
+                os_dly_wait(1);
+            }
             USBD_Handler();
         }
 

--- a/source/daplink/interface/main.h
+++ b/source/daplink/interface/main.h
@@ -23,6 +23,7 @@
 #define MAIN_H
 
 #include "stdint.h"
+#include "stdbool.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -51,6 +52,7 @@ typedef enum main_reset_state {
 } main_reset_state_t;
 
 void main_reset_target(uint8_t send_unique_id);
+void main_usb_set_test_mode(bool enabled);
 void main_usb_configure_event(void);
 void main_usb_busy_event(void);
 void main_powerdown_event(void);

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -67,6 +67,7 @@ from enum import Enum
 from hid_test import test_hid
 from serial_test import test_serial
 from msd_test import test_mass_storage
+from usb_test import test_usb
 from daplink_board import get_all_attached_daplink_boards
 from project_generator.generate import Generator
 from test_info import TestInfo
@@ -91,6 +92,7 @@ def test_endpoints(workspace, parent_test):
     test_hid(workspace, test_info)
     test_serial(workspace, test_info)
     test_mass_storage(workspace, test_info)
+    test_usb(workspace, test_info)
 
 
 class TestConfiguration(object):

--- a/test/test_info.py
+++ b/test/test_info.py
@@ -180,4 +180,4 @@ class TestInfoStub(TestInfo):
 
     @staticmethod
     def _print_msg(msg):
-        pass
+        print("%s" % (msg,))

--- a/test/usb_cdc.py
+++ b/test/usb_cdc.py
@@ -1,0 +1,182 @@
+#
+# DAPLink Interface Firmware
+# Copyright (c) 2016-2016, ARM Limited, All Rights Reserved
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import usb.util
+
+
+class USBCdc(object):
+    """Wrapper class for a CDC usb device"""
+
+    # Communication commands documented in
+    # PSTN120 inside CDC1.2_WMC1.1_012011
+
+    CLASS_CDC_DATA = 0xa
+    CLASS_CDC_COMM = 0x2
+
+    FORMAT_STOP_BITS_1_0 = 0
+    FORMAT_STOP_BITS_1_5 = 1
+    FORMAT_STOP_BITS_2_0 = 2
+
+    PARITY_NONE = 0
+    PARITY_ODD = 1
+    PARITY_EVEN = 2
+    PARITY_MARK = 3
+    PARITY_SPACE = 4
+
+    DATA_BITS_5 = 5
+    DATA_BITS_6 = 6
+    DATA_BITS_7 = 7
+    DATA_BITS_8 = 8
+    DATA_BITS_16 = 16
+
+    SEND_BREAK_ON = 0xFFFF
+    SEND_BREAK_OFF = 0x0000
+
+    def __init__(self, device):
+        self._dev = device
+        self._if_data = None
+        self._if_comm = None
+        self.ep_data_out = None
+        self.ep_data_in = None
+        self._locked = False
+        self.timeout = 10000
+
+        # Find interfaces
+        for interface in device.get_active_configuration():
+            if interface.bInterfaceClass == USBCdc.CLASS_CDC_DATA:
+                assert self._if_data is None
+                self._if_data = interface
+            if interface.bInterfaceClass == USBCdc.CLASS_CDC_COMM:
+                assert self._if_comm is None
+                self._if_comm = interface
+        assert self._if_data is not None
+        assert self._if_comm is not None
+
+        # Find endpoints
+        for endpoint in self._if_data:
+            if endpoint.bEndpointAddress & 0x80:
+                assert self.ep_data_in is None
+                self.ep_data_in = endpoint
+            else:
+                assert self.ep_data_out is None
+                self.ep_data_out = endpoint
+        assert self.ep_data_in is not None
+        assert self.ep_data_out is not None
+
+    def lock(self):
+        """Acquire exclisive access to CDC"""
+        assert not self._locked
+
+        for interface in (self._if_data, self._if_comm):
+            num = interface.bInterfaceNumber
+            try:
+                if self._dev.is_kernel_driver_active(num):
+                    self._dev.detach_kernel_driver(num)
+            except NotImplementedError:
+                pass
+            except usb.core.USBError:
+                pass
+            usb.util.claim_interface(self._dev, num)
+        self._locked = True
+
+    def unlock(self):
+        """Release exclusive access to CDC"""
+        assert self._locked
+
+        for interface in (self._if_data, self._if_comm):
+            num = interface.bInterfaceNumber
+            usb.util.release_interface(self._dev, num)
+            try:
+                self._dev.attach_kernel_driver(num)
+            except NotImplementedError:
+                pass
+            except usb.core.USBError:
+                pass
+        self._locked = False
+
+    def set_line_coding(self, baud, fmt=FORMAT_STOP_BITS_1_0,
+                        parity=PARITY_NONE, databits=DATA_BITS_8):
+        """Send the SetLineCoding CDC command"""
+        assert self._locked
+
+        data = bytearray(7)
+        data[0] = (baud >> (8 * 0)) & 0xFF
+        data[1] = (baud >> (8 * 1)) & 0xFF
+        data[2] = (baud >> (8 * 2)) & 0xFF
+        data[3] = (baud >> (8 * 3)) & 0xFF
+        data[4] = fmt
+        data[5] = parity
+        data[6] = databits
+
+        request_type = 0x21
+        request = 0x20                              # SET_LINE_CODING
+        value = 0                                   # Always 0 for this request
+        index = self._if_comm.bInterfaceNumber      # Communication interface
+        self._dev.ctrl_transfer(request_type, request, value, index, data,
+                                self.timeout)
+
+    def get_line_coding(self):
+        """Send the GetLineCoding CDC command
+
+        Returns a tuple containing
+        baud, fmt, parity, databits
+        """
+        assert self._locked
+
+        request_type = 0xA1
+        request = 0x21                              # GET_LINE_CODING
+        value = 0                                   # Always 0 for this request
+        index = self._if_comm.bInterfaceNumber      # Communication interface
+        resp = self._dev.ctrl_transfer(request_type, request, value, index, 7,
+                                       self.timeout)
+        baud = (((resp[0] & 0xFF) << (8 * 0)) |
+                ((resp[1] & 0xFF) << (8 * 1)) |
+                ((resp[2] & 0xFF) << (8 * 2)) |
+                ((resp[3] & 0xFF) << (8 * 3)))
+        fmt = resp[4]
+        parity = resp[5]
+        databits = resp[6]
+        return (baud, fmt, parity, databits)
+
+    def send_break(self, break_time):
+        """Send the SendBreak CDC command"""
+        assert self._locked
+        assert break_time & ~0xFFFF == 0, "Value outside of supported range"
+
+        request_type = 0x21
+        request = 0x23                              # SEND_BREAK
+        value = break_time                          # Duration of break in ms
+        index = self._if_comm.bInterfaceNumber      # Communication interface
+        self._dev.ctrl_transfer(request_type, request, value, index, None,
+                                self.timeout)
+
+    def read(self, size, timeout=None):
+        """Read from the CDC data endpoint"""
+        assert self._locked
+
+        if timeout is None:
+            timeout = self.timeout
+        return self.ep_data_in.read(size, timeout)
+
+    def write(self, data, timeout=None):
+        """Write to the CDC data endpoint"""
+        assert self._locked
+
+        if timeout is None:
+            timeout = self.timeout
+        self.ep_data_out.write(data, self.timeout)

--- a/test/usb_hid.py
+++ b/test/usb_hid.py
@@ -1,0 +1,162 @@
+#
+# DAPLink Interface Firmware
+# Copyright (c) 2016-2016, ARM Limited, All Rights Reserved
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import usb.util
+
+
+class USBHid(object):
+    """Wrapper class for a HID usb device"""
+
+    # HID commands documented in
+    # Device Class Definition for Human Interface Devices (HID)
+
+    CLASS_HID = 0x3
+
+    DESC_TYPE_HID = 0x21
+    DESC_TYPE_REPORT = 0x22
+    DESC_TYPE_PHYSICAL = 0x23
+
+    REPORT_TYPE_INPUT = 1
+    REPORT_TYPE_OUTPUT = 2
+    REPORT_TYPE_FEATURE = 3
+
+    def __init__(self, device):
+        self._dev = device
+        self._if = None
+        self.ep_in = None
+        self.ep_out = None
+        self._locked = False
+        self.timeout = 10 * 1000
+
+        # Find interface
+        for interface in device.get_active_configuration():
+            if interface.bInterfaceClass == USBHid.CLASS_HID:
+                assert self._if is None
+                self._if = interface
+        assert self._if is not None
+
+        # Find endpoints
+        for endpoint in self._if:
+            if endpoint.bEndpointAddress & 0x80:
+                assert self.ep_in is None
+                self.ep_in = endpoint
+            else:
+                assert self.ep_out is None
+                self.ep_out = endpoint
+        assert self.ep_in is not None
+        # Endpoint out can be None
+
+    def lock(self):
+        """Acquire exclisive access to HID"""
+        assert not self._locked
+
+        num = self._if.bInterfaceNumber
+        try:
+            if self._dev.is_kernel_driver_active(num):
+                self._dev.detach_kernel_driver(num)
+        except NotImplementedError:
+            pass
+        except usb.core.USBError:
+            pass
+        usb.util.claim_interface(self._dev, num)
+        self._locked = True
+
+    def unlock(self):
+        """Release exclusive access to HID"""
+        assert self._locked
+
+        num = self._if.bInterfaceNumber
+        usb.util.release_interface(self._dev, num)
+        try:
+            self._dev.attach_kernel_driver(num)
+        except NotImplementedError:
+            pass
+        except usb.core.USBError:
+            pass
+        self._locked = False
+
+    def set_idle(self, report_id=0, duration=0):
+        """Send a HID Set_Idle request"""
+        assert self._locked
+        assert report_id & ~0xFF == 0
+        assert duration & ~0xFF == 0
+
+        request_type = 0x21
+        request = 0x0A                                  # SET_IDLE
+        value = ((duration << 8) | (report_id << 0))    # Report and duration
+        index = self._if.bInterfaceNumber       # HID interface
+        self._dev.ctrl_transfer(request_type, request, value, index, None)
+
+    def get_descriptor(self, desc_type, index):
+        """Get the given descriptor"""
+        assert self._locked
+        assert desc_type & ~0xFF == 0
+        assert index & ~0xFF == 0
+
+        request_type = 0x81
+        request = 0x6                             # GET_DESCRIPTOR
+        value = (((index & 0xFF) << (0 * 8)) |
+                 ((desc_type & 0xFF) << (1 * 8)))  # Descriptor type and index
+        index = self._if.bInterfaceNumber          # HID interface
+        return self._dev.ctrl_transfer(request_type, request,
+                                       value, index, 256)
+
+    def set_report_req(self, data, report_type=REPORT_TYPE_OUTPUT,
+                       report_id=0):
+        """Set a report of the given type"""
+        assert self._locked
+        assert report_type & ~0xFF == 0
+        assert report_id & ~0xFF == 0
+
+        request_type = 0x21
+        request = 0x09                          # SET_REPORT
+        value = ((report_type << 8) |
+                 (report_id << 0))              # Report and duration
+        index = self._if.bInterfaceNumber       # HID interface
+        self._dev.ctrl_transfer(request_type, request, value, index, data,
+                                self.timeout)
+
+    def get_report_req(self, data_size, report_type=REPORT_TYPE_INPUT,
+                       report_id=0):
+        """Set a report of the given type"""
+        assert self._locked
+        assert report_type & ~0xFF == 0
+        assert report_id & ~0xFF == 0
+
+        request_type = 0xA1
+        request = 0x01                          # SET_REPORT
+        value = ((report_type << 8) |
+                 (report_id << 0))              # Report and duration
+        index = self._if.bInterfaceNumber       # HID interface
+        return self._dev.ctrl_transfer(request_type, request, value, index,
+                                       data_size, self.timeout)
+
+    def set_report(self, data):
+        """Send report to the device"""
+        assert self._locked
+
+        if self.ep_out is None:
+            self.set_report_req(data)
+        else:
+            self.ep_out.write(data, 10 * 1000)
+
+    def get_report(self, size):
+        """Read report from the device"""
+        assert self._locked
+
+        return self.ep_in.read(size, 10 * 1000)

--- a/test/usb_msd.py
+++ b/test/usb_msd.py
@@ -1,0 +1,387 @@
+#
+# DAPLink Interface Firmware
+# Copyright (c) 2016-2016, ARM Limited, All Rights Reserved
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import struct
+import numbers
+import time
+import usb.util
+
+
+class USBMsd(object):
+    """Wrapper class for a MSD usb device"""
+
+    # Bulk only transport documented in
+    #     "Universal Serial Bus Mass Storage Class"
+    # SCSI commands documented in "SCSI Commands Reference Manual" by Seagate
+
+    CLASS_MSD = 0x8
+    # Write 10
+    # Read 10
+    # Test unit ready
+    # Request Sense
+
+    # dCBWSignature
+    # dCBWTag
+    # dCBWDataTransferLength
+    # bmCBWFlags
+    # bCBWLUN
+    # bCBWCBLength
+    FMT_CBW = "<IIIBBB"
+
+    # dCSWSignature
+    # dCSWTag
+    # dCSWDataResidue
+    # bCSWStatus
+    FMT_CSW = "<IIIB"
+
+    CSW_STATUS_PASSED = 0
+    CSW_STATUS_FAILED = 1
+    CSW_STATUS_PHASE_ERROR = 2
+
+    class SCSIError(Exception):
+
+        def __init__(self, error):
+            Exception.__init__(self)
+            self.value = error
+
+    # Some SCSI commands
+    # Value   Keil middleware define         Seagate name
+    # 0x12    SCSI_INQUIRY                   INQUIRY
+    # 0x23    SCSI_READ_FORMAT_CAPACITIES    Missing
+    # 0x25    SCSI_READ_CAPACITY             READ CAPACITY (10)
+    # 0x28    SCSI_READ10                    READ (10)
+    # 0x1A    SCSI_MODE_SENSE6               MODE SENSE (6)
+    # 0x00    SCSI_TEST_UNIT_READY           TEST UNIT READY
+    # 0x2A    SCSI_WRITE10                   WRITE (10)
+    # 0x03    SCSI_REQUEST_SENSE             REQUEST SENSE
+    # 0x1E    SCSI_MEDIA_REMOVAL             Missing
+
+    def __init__(self, device):
+        self._dev = device
+        self._if = None
+        self.ep_in = None
+        self.ep_out = None
+        self._locked = False
+        self._cbw_tag = 0
+        self.timeout = 60 * 1000
+        # delays are for testing only
+        self.delay_cbw_to_data = 0
+        self.delay_data_to_csw = 0
+
+        # Find interface
+        for interface in device.get_active_configuration():
+            if interface.bInterfaceClass == USBMsd.CLASS_MSD:
+                assert self._if is None
+                self._if = interface
+        assert self._if is not None
+
+        # Find endpoints
+        for endpoint in self._if:
+            if endpoint.bEndpointAddress & 0x80:
+                assert self.ep_in is None
+                self.ep_in = endpoint
+            else:
+                assert self.ep_out is None
+                self.ep_out = endpoint
+        assert self.ep_in is not None
+        assert self.ep_out is not None
+
+    def lock(self):
+        """Acquire exclisive access to MSD"""
+        assert not self._locked
+
+        num = self._if.bInterfaceNumber
+        try:
+            if self._dev.is_kernel_driver_active(num):
+                self._dev.detach_kernel_driver(num)
+        except NotImplementedError:
+            pass
+        except usb.core.USBError:
+            pass
+        usb.util.claim_interface(self._dev, num)
+        self._locked = True
+
+    def unlock(self):
+        """Release exclusive access to MSD"""
+        assert self._locked
+
+        num = self._if.bInterfaceNumber
+        usb.util.release_interface(self._dev, num)
+        try:
+            self._dev.attach_kernel_driver(num)
+        except NotImplementedError:
+            pass
+        except usb.core.USBError:
+            pass
+        self._locked = False
+
+    def scsi_read10(self, lba, block_count):
+        """Send the SCSI read 10 command and return the data read"""
+        block_size = 512
+
+        cbwcb = bytearray(10)
+        cbwcb[0] = 0x28
+        cbwcb[2] = (lba >> (8 * 3)) & 0xFF
+        cbwcb[3] = (lba >> (8 * 2)) & 0xFF
+        cbwcb[4] = (lba >> (8 * 1)) & 0xFF
+        cbwcb[5] = (lba >> (8 * 0)) & 0xFF
+        cbwcb[7] = (block_count >> (8 * 1)) & 0xFF
+        cbwcb[8] = (block_count >> (8 * 0)) & 0xFF
+        ret, data = self._msd_transfer(cbwcb, 0, block_count * block_size)
+        if ret != self.CSW_STATUS_PASSED:
+            raise self.SCSIError(ret)
+        return data
+
+    def scsi_write10(self, lba, data):
+        """Send the SCSI write 10 command"""
+        block_size = 512
+
+        assert len(data) % block_size == 0
+        block_count = (len(data) + (block_size - 1)) // block_size
+
+        cbwcb = bytearray(10)
+        cbwcb[0] = 0x2A
+        cbwcb[2] = (lba >> (8 * 3)) & 0xFF
+        cbwcb[3] = (lba >> (8 * 2)) & 0xFF
+        cbwcb[4] = (lba >> (8 * 1)) & 0xFF
+        cbwcb[5] = (lba >> (8 * 0)) & 0xFF
+        cbwcb[7] = (block_count >> (8 * 1)) & 0xFF
+        cbwcb[8] = (block_count >> (8 * 0)) & 0xFF
+        ret, _ = self._msd_transfer(cbwcb, 0, data)
+        if ret != self.CSW_STATUS_PASSED:
+            raise self.SCSIError(ret)
+
+    def scsi_test_unit_ready(self):
+        """Send the SCSI test unit ready command and return status"""
+        cbwcb = bytearray(10)
+        cbwcb[0] = 0
+        ret, _ = self._msd_transfer(cbwcb, 0)
+        return ret
+
+    def _msd_transfer(self, cbwcb, lun, size_or_data=None):
+        """Perform a bulk only transfer"""
+        assert self._locked
+        assert 1 <= len(cbwcb) <= 16
+
+        # Increment packet tag
+        transfer_tag = self._cbw_tag
+        self._cbw_tag = (self._cbw_tag + 1) & 0xFFFFFFFF
+
+        # None means data size of zero
+        if size_or_data is None:
+            size_or_data = 0
+
+        in_transfer = isinstance(size_or_data, numbers.Number)
+        transfer_size = (size_or_data if in_transfer else len(size_or_data))
+        assert in_transfer or len(size_or_data) > 0
+
+        # Phase - Command transport
+        cbw_signature = 0x43425355
+        cbw_tag = transfer_tag
+        cbw_data_transfer_length = transfer_size
+        cbw_flags = (1 << 7) if in_transfer else 0
+        cbw_lun = lun
+        cbw_length = len(cbwcb)
+        params = [cbw_signature, cbw_tag, cbw_data_transfer_length,
+                  cbw_flags, cbw_lun, cbw_length]
+        cbw = struct.pack(self.FMT_CBW, *params)
+        pad_size = 16 - len(cbwcb)
+        payload = cbw + cbwcb + bytearray(pad_size)
+        self.ep_out.write(payload)
+
+        if self.delay_cbw_to_data != 0:
+            time.sleep(self.delay_cbw_to_data)
+
+        # Phase - Data Out or Data In (Optional)
+        data = None
+        if transfer_size > 0:
+            endpoint = self.ep_in if in_transfer else self.ep_out
+            try:
+                if in_transfer:
+                    data = self.ep_in.read(transfer_size, self.timeout)
+                else:
+                    self.ep_out.write(size_or_data, self.timeout)
+            except usb.core.USBError:
+                endpoint.clear_halt()
+
+        if self.delay_data_to_csw != 0:
+            time.sleep(self.delay_data_to_csw)
+
+        # Phase - Status Transport
+        csw = self.ep_in.read(13, self.timeout)
+        csw_signature, csw_tag, csw_data_residue, csw_status = \
+            struct.unpack(self.FMT_CSW, csw)
+        assert csw_signature == 0x53425355
+        assert csw_tag == transfer_tag
+        #TODO - check residue
+        return (csw_status, data)
+
+
+class Struct(object):
+    """Base class for a C structure"""
+
+    def __init__(self, name, structure, data):
+        field_list = [field[0] for field in structure]
+        fmt_list = [field[1] for field in structure]
+        format_str = "<" + "".join(fmt_list)
+        struct_size = struct.calcsize(format_str)
+        value_list = struct.unpack(format_str, data[:struct_size])
+        value_dict = {}
+        for name, value in zip(field_list, value_list):
+            value_dict[name] = value
+        self.name = name
+        self.format_str = format_str
+        self.field_list = field_list
+        self.value_dict = value_dict
+        self.size = struct_size
+
+    def __getitem__(self, key):
+        return self.value_dict[key]
+
+    def __setitem__(self, key, value):
+        self.value_dict[key] = value
+
+    def __str__(self):
+        desc = ""
+        desc += self.name + ":" + os.linesep
+        for field in self.field_list:
+            value = self.value_dict[field]
+            if isinstance(value, bytes):
+                value = list(bytearray(value))
+            desc += ("    %s=%s" + os.linesep) % (field, value)
+        return desc
+
+    def pack(self):
+        """Return a byte representation of this structure"""
+        value_list = []
+        for field in self.field_list:
+            value_list.append(self.value_dict[field])
+        return struct.pack(self.format_str, *value_list)
+
+
+class MBR(Struct):
+    """Wrapper class for a FAT MBR"""
+
+    STRUCTURE = (
+        ("BS_jmpBoot", "3s"),
+        ("BS_OEMName", "8s"),
+        ("BPB_BytsPerSec", "H"),
+        ("BPB_SecPerClus", "B"),
+        ("BPB_RsvdSecCnt", "H"),
+        ("BPB_NumFATs", "B"),
+        ("BPB_RootEntCnt", "H"),
+        ("BPB_TotSec16", "H"),
+        ("BPB_Media", "B"),
+        ("BPB_FATSz16", "H"),
+        ("BPB_SecPerTrk", "H"),
+        ("BPB_NumHeads", "H"),
+        ("BPB_HiddSec", "L"),
+        ("BPB_TotSec32", "L"),
+        )
+
+    def __init__(self, data, sector=None):
+        Struct.__init__(self, "MBR", self.STRUCTURE, data)
+        self.sector = sector
+
+
+class DirectoryEntry(Struct):
+    """Wrapper class for a FAT DirectoryEntry"""
+
+    STRUCTURE = (
+        ("DIR_Name", "11s"),
+        ("DIR_Attr", "B"),
+        ("DIR_NTRes", "B"),
+        ("DIR_CrtTimeTenth", "B"),
+        ("DIR_CrtTime", "H"),
+        ("DIR_CrtDate", "H"),
+        ("DIR_LstAccDate", "H"),
+        ("DIR_FstClusHI", "H"),
+        ("DIR_WrtTime", "H"),
+        ("DIR_WrtDate", "H"),
+        ("DIR_FstClusLO", "H"),
+        ("DIR_FileSize", "L"),
+        )
+
+    def __init__(self, data):
+        Struct.__init__(self, "DirectoryEntry", self.STRUCTURE, data)
+
+
+class Directory(object):
+    """Wrapper class for a FAT Directory"""
+
+    ENTRY_SIZE = 32
+
+    def __init__(self, entry_count, data, sector=None):
+        directory_list = []
+        for i in range(entry_count):
+            start = i * self.ENTRY_SIZE
+            dir_data = data[start:start + self.ENTRY_SIZE]
+            entry = DirectoryEntry(dir_data)
+            directory_list.append(entry)
+        self.directory_list = directory_list
+        self.sector = sector
+
+    def __iter__(self):
+        return iter(self.directory_list)
+
+    def __getitem__(self, key):
+        return self.directory_list[key]
+
+    def find_free_entry_index(self):
+        """Find a free index in this Directory or return None"""
+        for idx, directory in enumerate(self.directory_list):
+            name_data = bytearray(directory["DIR_Name"])
+            if name_data[0] in (0x00, 0xE5):
+                return idx
+        return None
+
+    def pack(self):
+        """Return a byte a Directory"""
+        data = bytearray()
+        for directory in self.directory_list:
+            data.extend(directory.pack())
+        return data
+
+
+class Fat(object):
+    """Wrapper class for a FAT filesystem on a SCSI device"""
+
+    SECTOR_SIZE = 512
+    CLUSTER_SIZE = 4 * 1024
+
+    def __init__(self, msd):
+        self.msd = msd
+        self.reload()
+
+    def reload(self):
+        """Reload all internal data of this Fat filesystem"""
+
+        # Read MBR
+        mbr_data = self.msd.scsi_read10(0, 1)
+        mbr = MBR(mbr_data, 0)
+
+        # Read in the root directory
+        root_dir_sec = (mbr["BPB_RsvdSecCnt"] +
+                        (mbr["BPB_NumFATs"] * mbr["BPB_FATSz16"]))
+        sec_count = (mbr["BPB_RootEntCnt"] * 32 + 512 - 1) // 512
+        root_dir_data = self.msd.scsi_read10(root_dir_sec, sec_count)
+        root_dir = Directory(mbr["BPB_RootEntCnt"], root_dir_data,
+                             root_dir_sec)
+        self.mbr = mbr
+        self.root_dir = root_dir

--- a/test/usb_test.py
+++ b/test/usb_test.py
@@ -1,0 +1,439 @@
+#
+# DAPLink Interface Firmware
+# Copyright (c) 2016-2016, ARM Limited, All Rights Reserved
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+""" Module for low level and targeted USB tests"""
+
+from __future__ import print_function
+
+import os
+import usb.core
+import functools
+import threading
+import time
+from usb_cdc import USBCdc
+from usb_hid import USBHid
+from usb_msd import USBMsd, Fat
+
+DISMOUNT_TIME_S = 10.00
+
+
+def test_usb(workspace, parent_test, force=False):
+    """Run raw USB tests
+
+    Requirements:
+        -daplink-validation must be loaded for the target.
+    """
+
+    # Only test on supported platforms
+    if not _platform_supports_usb_test() and not force:
+        parent_test.info("Skipping USB test on this platform")
+        return
+    test_info = parent_test.create_subtest("USB test")
+
+    # Find the device under test
+    serial_number = workspace.board.get_unique_id()
+    dev = _daplink_from_serial_number(serial_number)
+    if dev is None:
+        test_info.failure("Could not find board with serial number %s" %
+                          serial_number)
+        return
+
+    # Create wrappers for and acquire exclusive access to interfaces
+    cdc = USBCdc(dev)
+    hid = USBHid(dev)
+    msd = USBMsd(dev)
+    cdc.lock()
+    hid.lock()
+    msd.lock()
+
+    try:
+
+        for usb_test_on in (False, True):
+
+            _set_usb_test_mode(hid, usb_test_on)
+
+            test_cdc(test_info, cdc)
+
+            test_hid(test_info, hid)
+
+            test_msd(test_info, msd)
+
+            test_msd_stall(test_info, msd)
+
+            test_control(test_info, dev, cdc, hid, msd)
+
+            test_all(test_info, cdc, hid, msd)
+
+            # TODO - future enhancements
+            #  MSD remount + hid
+            #  STALL IN and STALL OUT
+
+    finally:
+        try:
+            _set_usb_test_mode(hid, False)
+        except usb.core.USBError:
+            pass
+        cdc.unlock()
+        hid.unlock()
+        msd.unlock()
+
+
+def main():
+    """Run the usb test as a stand alone program"""
+
+    import test_info
+    import mock
+
+    def get_unique_id(unique_id):
+        """Mock function to return a unique id"""
+        return unique_id
+
+    dev_list = usb.core.find(find_all=True, custom_match=_daplink_match)
+    for dev in dev_list:
+        board_id = dev.serial_number
+        print("Testing board %s" % board_id)
+        print("----------------")
+        mock_ws = mock.Mock()
+        mock_ws.board = mock.Mock()
+        mock_ws.board.unique_id = dev.serial_number
+        mock_ws.board.get_unique_id = functools.partial(get_unique_id,
+                                                        board_id)
+        test_usb(mock_ws, test_info.TestInfoStub(), True)
+
+
+def test_cdc(test_info, cdc):
+    """Smoke test of the CDC endpoint"""
+    cdc.set_line_coding(115200)
+    baud, fmt, parity, databits = cdc.get_line_coding()
+    test_info.info("Baud %i, fmt %i, parity %i, databits %i" %
+                   (baud, fmt, parity, databits))
+    cdc.send_break(cdc.SEND_BREAK_ON)
+    cdc.send_break(cdc.SEND_BREAK_OFF)
+    data = cdc.read(1024)
+    test_info.info("Serial port data: %s" % bytearray(data))
+    cdc.write("Hello world")
+    data = cdc.read(1024)
+    test_info.info("Serial port data2: %s" % bytearray(data))
+
+
+def test_hid(test_info, hid):
+    """Smoke test of the HID endpoint"""
+    hid.set_idle()
+    report = hid.get_descriptor(hid.DESC_TYPE_REPORT, 0)
+    test_info.info("Report descriptor: %s" % report)
+    # Send CMSIS-DAP vendor command to get the serial number
+    data = bytearray(64)
+    data[0] = 0x80
+    hid.set_report(data)
+    resp = hid.get_report(64)
+    length = resp[1]
+    test_info.info("CMSIS-DAP response: %s" %
+                   bytearray(resp[1:1 + length]).decode("utf-8"))
+
+
+def test_msd(test_info, msd):
+    """MSD endpoint tests"""
+
+    # Simple read
+    mbr = msd.scsi_read10(0, 1)
+    test_info.info("MBR[0:16]: %s" % mbr[0:16])
+
+    # Test FAT filesystem
+    fat = Fat(msd)
+    print(fat.mbr)
+
+    # Grab entries in the root directory
+    root_dir = fat.root_dir
+    for entry in root_dir:
+        if entry["DIR_Name"][0] != "\0":
+            print(entry)
+
+    # Trigger a remount
+    dir_idx = root_dir.find_free_entry_index()
+    root_dir[dir_idx]["DIR_Name"] = "REFRESH ACT"
+    root_dir_data = root_dir.pack()
+    msd.scsi_write10(root_dir.sector, root_dir_data)
+
+    test_info.info("Added file to root directory")
+    start = time.time()
+    while time.time() - start < DISMOUNT_TIME_S:
+        try:
+            msd.scsi_read10(0, 1)
+        except msd.SCSIError:
+            test_info.info("Dismount detected")
+            break
+    else:
+        test_info.failure("Device failed to dismount")
+
+    start = time.time()
+    while time.time() - start < DISMOUNT_TIME_S:
+        try:
+            msd.scsi_read10(0, 1)
+            test_info.info("Mount detected")
+            break
+        except msd.SCSIError:
+            pass
+    else:
+        test_info.failure("Device failed to mount")
+
+
+def test_msd_stall(test_info, msd):
+    """Test stalls coming at various times in the middle of MSD xfers"""
+    fat = Fat(msd)
+    root_dir = fat.root_dir
+    dir_idx = root_dir.find_free_entry_index()
+    root_dir[dir_idx]["DIR_Name"] = "REFRESH ACT"
+    root_dir_data = root_dir.pack()
+
+    # Test that a write fails if media is removed after the CBW
+    # stage but before the CSW stage
+    msd.scsi_write10(root_dir.sector, root_dir_data)
+    msd.delay_cbw_to_data = 1.0
+    retval = msd.CSW_STATUS_PASSED
+    try:
+        msd.scsi_write10(0, bytearray(512))
+        test_info.failure("Device failed to stall data stage")
+    except msd.SCSIError as error:
+        retval = error.value
+    msd.delay_cbw_to_data = 0
+    # Make sure device still works as expected
+    time.sleep(3)
+    msd.scsi_read10(0, 1)
+    msd.scsi_write10(0, bytearray(512))
+    if retval == msd.CSW_STATUS_FAILED:
+        test_info.info("Test CBW,Stall,Data OUT - Pass")
+    else:
+        test_info.failure("Device returned wrong status")
+
+    # Test that a write succeeds even if media is removed
+    # after the OUT stage but before the CSW stage
+    msd.scsi_write10(root_dir.sector, root_dir_data)
+    msd.delay_data_to_csw = 1.0
+    msd.scsi_write10(0, bytearray(512))
+    msd.delay_data_to_csw = 0
+    # Make sure device still works as expected
+    time.sleep(3)
+    msd.scsi_read10(0, 1)
+    msd.scsi_write10(0, bytearray(512))
+    test_info.info("Test DATA OUT,Stall,CSW - Pass")
+
+    # Test that a read succeeds even if media is removed
+    # after the IN stage but before the CSW stage
+    msd.scsi_write10(root_dir.sector, root_dir_data)
+    msd.delay_data_to_csw = 1.0
+    resp = msd.scsi_read10(0, 1)
+    assert len(resp) == 512
+    msd.delay_data_to_csw = 0
+    # Make sure device still works as expected
+    time.sleep(3)
+    msd.scsi_read10(0, 1)
+    msd.scsi_write10(0, bytearray(512))
+    test_info.info("Test DATA IN,Stall,CSW - Pass")
+
+    # Test that a test unit ready succeeds even if media is removed
+    # after the CBW stage but before the CSW stage
+    msd.scsi_write10(root_dir.sector, root_dir_data)
+    msd.delay_data_to_csw = 1.0
+    resp = msd.scsi_test_unit_ready()
+    msd.delay_data_to_csw = 0
+    # Make sure device still works as expected
+    time.sleep(3)
+    msd.scsi_read10(0, 1)
+    msd.scsi_write10(0, bytearray(512))
+    if resp == msd.CSW_STATUS_PASSED:
+        test_info.info("Test CBW,Stall,CSW - Pass")
+    else:
+        test_info.failure("Test CBW,Stall,CSW - Failed")
+
+    # Test that a test unit ready succeeds even if media is removed
+    # after the CBW stage but before the CSW stage
+    msd.scsi_write10(root_dir.sector, root_dir_data)
+    time.sleep(1.0)
+    resp = msd.scsi_test_unit_ready()
+    # Make sure device still works as expected
+    time.sleep(3)
+    msd.scsi_read10(0, 1)
+    msd.scsi_write10(0, bytearray(512))
+    if resp == msd.CSW_STATUS_FAILED:
+        test_info.info("Test CBW,Stall,CSW - Pass")
+    else:
+        test_info.failure("Test CBW,Stall,CSW - Failed")
+
+
+def test_control(test_info, dev, cdc, hid, msd):
+    """Test for the control endpoint"""
+
+    test_info.info("testing control transfer with size a multiple of 256")
+    request_type = 0x80
+    request = 0x06            # Get descriptor
+    value = 0x200              # Configuration descriptor
+    index = 0                  # Always 0 for this request
+    resp = dev.ctrl_transfer(request_type, request, value, index, 256)
+    assert len(resp) > 0
+
+    test_info.info("testing control commands")
+    # Test various patterns of control transfers
+    #
+    # Some devices have had problems with back-to-back
+    # control transfers. Intentionally send these sequences
+    # to make sure they are properly handled.
+    for _ in range(100):
+        # Control transfer with a data in stage
+        cdc.get_line_coding()
+    for _ in range(100):
+        # Control transfer with a data out stage followed
+        # by a control transfer with a data in stage
+        cdc.set_line_coding(115200)
+        cdc.get_line_coding()
+    for _ in range(100):
+        # Control transfer with a data out stage
+        cdc.set_line_coding(115200)
+
+    test_info.info("testing endpoint clearing")
+
+    cdc.ep_data_out.clear_halt()
+    cdc.ep_data_out.write('')      # DATA0
+    cdc.ep_data_out.clear_halt()
+    cdc.ep_data_out.write('')      # DATA0
+
+    cdc.ep_data_out.clear_halt()
+    cdc.ep_data_out.write('')      # DATA 0
+    cdc.ep_data_out.write('')      # DATA 1
+    cdc.ep_data_out.clear_halt()
+    cdc.ep_data_out.write('')      # DATA 0
+
+
+def test_all(test_info, cdc, hid, msd):
+    """Test all endpoints in parallel"""
+    mutex = threading.RLock()
+    terminate = False
+    error_msg_list = []
+
+    def _safe_print(message):
+        """Thread safe wrapper to print messages"""
+        with mutex:
+            print(message)
+
+    def _test_msd():
+        """MSD thread entry point for parallel testing"""
+        try:
+            _safe_print("msd started")
+            while not terminate:
+                msd_data = 'x' * 1024 * 16  # 16KB
+                msd.scsi_write10(100, msd_data)
+            _safe_print("msd end")
+        except:
+            error_msg_list.append("MSD test failed")
+            raise
+
+    def _test_cdc():
+        """CDC thread entry point for parallel testing"""
+        try:
+            _safe_print("cdc started")
+            while not terminate:
+                cdc.set_line_coding(115200)
+                cdc.get_line_coding()
+                cdc.send_break(cdc.SEND_BREAK_ON)
+                cdc.send_break(cdc.SEND_BREAK_OFF)
+                cdc.read(1024)
+                cdc.write("Hello world")
+                cdc.read(1024)
+            _safe_print("cdc end")
+        except:
+            error_msg_list.append("CDC test failed")
+            raise
+
+    def _test_hid():
+        """HID thread entry point for parallel testing"""
+        try:
+            _safe_print("hid started")
+            data = bytearray(64)
+            data[0] = 0x80
+            while not terminate:
+                hid.set_report(data)
+                resp = hid.get_report(64)
+                assert resp[0] == 0x80
+            _safe_print("hid end")
+        except:
+            error_msg_list.append("HID test failed")
+            raise
+
+    thread_list = []
+    for function in (_test_msd, _test_cdc, _test_hid):
+        thread = threading.Thread(target=function)
+        thread.start()
+        thread_list.append(thread)
+
+    time.sleep(10)
+
+    terminate = True
+    for thread in thread_list:
+        thread.join()
+
+    for error in error_msg_list:
+        test_info.failure(error)
+
+
+def _daplink_match(dev):
+    """DAPLink match function to be used with usb.core.find"""
+    try:
+        device_string = dev.product
+    except ValueError:
+        return False
+    if device_string is None:
+        return False
+    if device_string.find("CMSIS-DAP") < 0:
+        return False
+    return True
+
+
+def _daplink_from_serial_number(serial_number):
+    """Return a usb handle to the DAPLink device with the serial number"""
+    dev_list = usb.core.find(find_all=True, custom_match=_daplink_match)
+    for dev in dev_list:
+        if dev.serial_number == serial_number:
+            return dev
+    return None
+
+
+def _platform_supports_usb_test():
+    """Return True if this platform supports USB testing, False otherwise"""
+    if os.name != "posix":
+        return False
+    if not hasattr(os, 'uname'):
+        if False:
+            # Hack to supress warnings for uname not existing
+            os.uname = lambda: [None]
+        return False
+    if os.uname()[0] == "Darwin":
+        return False
+    return True
+
+
+def _set_usb_test_mode(hid, enabled):
+    """Set to True to enable USB testing mode"""
+    data = bytearray(64)
+    data[0] = 0x88
+    data[1] = 1 if enabled else 0
+    hid.set_report(data)
+    resp = hid.get_report(64)
+    if (resp[0] != 0x88) or (resp[1] != 1):
+        raise Exception("Error configuring USB test mode")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add tests at the USB level to reproduce and test for problems that can't be reliably reproduced when using the host msd,  cdc and hid drivers. Also, add a DAPLink USB test command to simulate worst case device USB driver latency.