### PR TITLE
Add runtime option to enable uart flow control

### DIFF
--- a/source/hic_hal/freescale/k20dx/uart.c
+++ b/source/hic_hal/freescale/k20dx/uart.c
@@ -186,6 +186,11 @@ int32_t uart_read_data(uint8_t *data, uint16_t size)
     return circ_buf_read(&read_buffer, data, size);
 }
 
+void uart_enable_flow_control(bool enabled)
+{
+    // Flow control not implemented for this platform
+}
+
 void UART1_RX_TX_IRQHandler(void)
 {
     uint32_t s1;

--- a/source/hic_hal/freescale/kl26z/uart.c
+++ b/source/hic_hal/freescale/kl26z/uart.c
@@ -206,6 +206,11 @@ int32_t uart_read_data(uint8_t *data, uint16_t size)
     return circ_buf_read(&read_buffer, data, size);
 }
 
+void uart_enable_flow_control(bool enabled)
+{
+    // Flow control not implemented for this platform
+}
+
 void UART_RX_TX_IRQHandler(void)
 {
     uint32_t s1;

--- a/source/hic_hal/nxp/lpc11u35/uart.c
+++ b/source/hic_hal/nxp/lpc11u35/uart.c
@@ -281,6 +281,10 @@ int32_t uart_read_data(uint8_t *data, uint16_t size)
     return circ_buf_read(&read_buffer, data, size);
 }
 
+void uart_enable_flow_control(bool enabled)
+{
+    // Flow control not implemented for this platform
+}
 
 void UART_IRQHandler(void)
 {

--- a/source/hic_hal/uart.h
+++ b/source/hic_hal/uart.h
@@ -23,6 +23,7 @@
 #define UART_H
 
 #include "stdint.h"
+#include "stdbool.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -84,6 +85,7 @@ extern int32_t uart_write_data(uint8_t *data, uint16_t size);
 extern int32_t uart_read_data(uint8_t *data, uint16_t size);
 extern void uart_set_control_line_state(uint16_t ctrl_bmp);
 extern void uart_software_flow_control(void);
+extern void uart_enable_flow_control(bool enabled);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Add the function uart_enable_flow_control() which allows flow control to be explicitly enabled or disabled. By default flow control is on on the platforms which support it.