### PR TITLE
Don't assert on unused targets when testing

### DIFF
--- a/test/target.py
+++ b/test/target.py
@@ -118,8 +118,6 @@ class Target(object):
         self._valid = False
         self._hex_path = None
         self._bin_path = None
-        assert name in info.TARGET_SET, 'Unknown target "%s" must be ' \
-            'added to SUPPORTED_CONFIGURATIONS in info.py' % name
         if hex_path is not None:
             self.set_hex_path(hex_path)
         if bin_path is not None:


### PR DESCRIPTION
When loading a bundle of targets, don't assert if the target isn't used. This allows new targets to be added in advance before DAPLink work starts.