### PR TITLE
Add framework for bootloader updates

### DIFF
--- a/docs/BOOTLOADER_UPDATES.md
+++ b/docs/BOOTLOADER_UPDATES.md
@@ -1,24 +1,24 @@
 # Bootloader updates
 
-DAPLink has the ability to bundle the bootloader firmware with the interface firmware and apply a bootloader update on the first boot of the interface. This allows bootloader updates to be applied as the same time as interface updates and without any special instructions for the user.
+DAPLink has the ability to bundle the bootloader firmware with the interface firmware and apply a bootloader update on the first boot of the interface. This allows bootloader updates to occur at the same time as interface updates and without any special instructions for the user.
 
 ### Enabling bootloader updates
 
-To enable bootloader updates for a board or interface circuit the value ```DAPLINK_BOOTLOADER_UPDATE``` must be defined. Once defined, the normal release process which documented on the [developers guide](DEVELOPERS-GUIDE.md) can be used to create firmware for all targets.
+To enable bootloader updates for a board or interface circuit, you must define the value ```DAPLINK_BOOTLOADER_UPDATE```. Once you define it, you can use the normal release process, which [developers guide](DEVELOPERS-GUIDE.md) documents, to create firmware for all targets.
 
 ### Safety when updating the bootloader
 
-The vector table of the bootloader is erased and replaced during the update. Because of this, there is a small window of time where if power is lost the device will be in a non-bootable state since it does not have a valid vector table. To minimize the time without a valid vector table and the reduce risk the bootloader vector table is replaced with the interface's vector table before the update is performed. This way while the bulk of the bootloader is being loaded there is a valid vector table and a loss of power event does not prevent the device from booting. The update process is shown below with the critical sections where power cannot be lost showin in bold:
-1. **Erase the boot vector table and program the intenterface's vector table to this location**
-1. Erase and program each sector of the bootloader with the new firmware
-1. **Erase the boot vector table and program the new bootloader's vector table to this location**
+The vector table of the bootloader is erased and replaced during the update. Because of this, there is a small window of time during which the device will be in a nonbootable state if the device loses power. The cause of this is the lack of a valid vector table. To minimize the time without a valid vector table and to reduce risk, the bootloader vector table is replaced with the interface's vector table before the update is performed. This way, while the bulk of the bootloader is being loaded, there is a valid vector table, and a loss of power event does not prevent the device from booting. The update process is below. The critical sections during which the device cannot lose power are in bold:
+1. **Erase the boot vector table, and program the intenterface's vector table to this location**.
+1. Erase and program each sector of the bootloader with the new firmware.
+1. **Erase the boot vector table, and program the new bootloader's vector table to this location**.
 
 Other checks
 * If the current bootloader has a valid signature and a version greater than the bootloader stored in interfacer has, the update will not be applied.
-* The interface does a checksum over itself to check for any corruption. If the interface is found to be corrupt the bootloader update will not be applied and an assert will appear on the device.
-* If the current bootloader is identical to the bootloader stored in the interface the update will not be applied.
+* The interface does a checksum over itself to check for any corruption. If it finds the interface corrupt, the bootloader update will not be applied, and an assert will appear on the device.
+* If the current bootloader is identical to the bootloader stored in the interface, the update will not be applied.
 
 ### Dangers
-* The DAPLink bootloader has a fixed location for where the interface is loaded (typically an offset of 0x8000 from the start of rom). If the bootloader you updated from had a different offset then the interface firmware you used with that bootloader will no longer work. You must use interface firmware built for the new offset.
-* This mechanism does not support downgrading or loading 3rd party bootloaders. To do this a debugger must be used or a custom build of DAPLink must be created.
-* The LPC11U35 does not have a bootloader, so bootloader updates cannot be used on this interface.
+* The DAPLink bootloader has a fixed location for where the interface is loaded (typically an offset of 0x8000 from the start of ROM). If the bootloader you updated from had a different offset than the interface firmware you used with that bootloader will no longer work. You must use interface firmware built for the new offset.
+* This mechanism does not support downgrading or loading third party bootloaders. To do this, you must use a debugger or create a custom build of DAPLink.
+* The LPC11U35 does not have a bootloader, so you cannot use bootloader updates on this interface.

--- a/docs/BOOTLOADER_UPDATES.md
+++ b/docs/BOOTLOADER_UPDATES.md
@@ -4,21 +4,23 @@ DAPLink has the ability to bundle the bootloader firmware with the interface fir
 
 ### Enabling bootloader updates
 
-To enable bootloader updates for a board or interface circuit, you must define the value ```DAPLINK_BOOTLOADER_UPDATE```. Once you define it, you can use the normal release process, which [developers guide](DEVELOPERS-GUIDE.md) documents, to create firmware for all targets.
+To enable bootloader updates for a board or interface circuit, you must define the value ```DAPLINK_BOOTLOADER_UPDATE```. Once you define it, you can use the normal release process, which the [developers guide](DEVELOPERS-GUIDE.md) documents, to create firmware for all targets.
 
 ### Safety when updating the bootloader
 
-The vector table of the bootloader is erased and replaced during the update. Because of this, there is a small window of time during which the device will be in a nonbootable state if the device loses power. The cause of this is the lack of a valid vector table. To minimize the time without a valid vector table and to reduce risk, the bootloader vector table is replaced with the interface's vector table before the update is performed. This way, while the bulk of the bootloader is being loaded, there is a valid vector table, and a loss of power event does not prevent the device from booting. The update process is below. The critical sections during which the device cannot lose power are in bold:
+The interface firmware erases and updates the vector table when updating the bootloader. Because of this, there is a small window of time during which the device will be in a nonbootable state if the device loses power. The cause of this is the lack of a valid vector table. To minimize the time without a valid vector table and to reduce risk, interface firmware replaces the bootloader's vector table with its own before performing the update. This way, while the bulk of the bootloader is being loaded, there is a valid vector table, and a loss of power event does not prevent the device from booting. The update process is below. The critical sections during which the device cannot lose power are in bold:
 1. **Erase the boot vector table, and program the intenterface's vector table to this location**.
 1. Erase and program each sector of the bootloader with the new firmware.
 1. **Erase the boot vector table, and program the new bootloader's vector table to this location**.
 
 Other checks
-* If the current bootloader has a valid signature and a version greater than the bootloader stored in interfacer has, the update will not be applied.
-* The interface does a checksum over itself to check for any corruption. If it finds the interface corrupt, the bootloader update will not be applied, and an assert will appear on the device.
-* If the current bootloader is identical to the bootloader stored in the interface, the update will not be applied.
+* The interface firmware will not downgrade the bootloader. If the current bootloader has a valid signature and a version greater than the the interface's copy of the bootloader then the interface will not replace the bootloader.
+* The interface firmware does a checksum over itself to check for any corruption. If it finds itself to be corrupt, it will not apply the bootloader update. In addition, an assert will appear on the on mass storage.
+* Before attempting to update the bootloader the interface firmware compares its internal copy of the bootloader to the curent bootloader. If they are the same then it does not apply an update.
 
 ### Dangers
-* The DAPLink bootloader has a fixed location for where the interface is loaded (typically an offset of 0x8000 from the start of ROM). If the bootloader you updated from had a different offset than the interface firmware you used with that bootloader will no longer work. You must use interface firmware built for the new offset.
+* The DAPLink bootloader has a fixed location for where the interface firmware is loaded (typically an offset of 0x8000 from the start of ROM). If you update to a bootloader that has a different offset then you will no longer be able to use the same interface firmware. Instead, you must use interface firmware built for the new offset.
+
+If the bootloader you updated from had a different offset than the interface firmware you used with that bootloader will no longer work. You must use interface firmware built for the new offset.
 * This mechanism does not support downgrading or loading third party bootloaders. To do this, you must use a debugger or create a custom build of DAPLink.
 * The LPC11U35 does not have a bootloader, so you cannot use bootloader updates on this interface.

--- a/docs/BOOTLOADER_UPDATES.md
+++ b/docs/BOOTLOADER_UPDATES.md
@@ -2,25 +2,26 @@
 
 DAPLink has the ability to bundle the bootloader firmware with the interface firmware and apply a bootloader update on the first boot of the interface. This allows bootloader updates to occur at the same time as interface updates and without any special instructions for the user.
 
-### Enabling bootloader updates
+## Enabling bootloader updates
 
 To enable bootloader updates for a board or interface circuit, you must define the value ```DAPLINK_BOOTLOADER_UPDATE```. Once you define it, you can use the normal release process, which the [developers guide](DEVELOPERS-GUIDE.md) documents, to create firmware for all targets.
 
-### Safety when updating the bootloader
+## Safety when updating the bootloader
 
 The interface firmware erases and updates the vector table when updating the bootloader. Because of this, there is a small window of time during which the device will be in a nonbootable state if the device loses power. The cause of this is the lack of a valid vector table. To minimize the time without a valid vector table and to reduce risk, interface firmware replaces the bootloader's vector table with its own before performing the update. This way, while the bulk of the bootloader is being loaded, there is a valid vector table, and a loss of power event does not prevent the device from booting. The update process is below. The critical sections during which the device cannot lose power are in bold:
+
 1. **Erase the boot vector table, and program the intenterface's vector table to this location**.
 1. Erase and program each sector of the bootloader with the new firmware.
 1. **Erase the boot vector table, and program the new bootloader's vector table to this location**.
 
 Other checks
-* The interface firmware will not downgrade the bootloader. If the current bootloader has a valid signature and a version greater than the the interface's copy of the bootloader then the interface will not replace the bootloader.
+* The interface firmware will not downgrade the bootloader. If the current bootloader has a valid signature and a version greater than the interface's copy of the bootloader then the interface will not replace the bootloader.
 * The interface firmware does a checksum over itself to check for any corruption. If it finds itself to be corrupt, it will not apply the bootloader update. In addition, an assert will appear on the on mass storage.
 * Before attempting to update the bootloader the interface firmware compares its internal copy of the bootloader to the curent bootloader. If they are the same then it does not apply an update.
 
-### Dangers
+## Dangers
+
 * The DAPLink bootloader has a fixed location for where the interface firmware is loaded (typically an offset of 0x8000 from the start of ROM). If you update to a bootloader that has a different offset then you will no longer be able to use the same interface firmware. Instead, you must use interface firmware built for the new offset.
 
-If the bootloader you updated from had a different offset than the interface firmware you used with that bootloader will no longer work. You must use interface firmware built for the new offset.
 * This mechanism does not support downgrading or loading third party bootloaders. To do this, you must use a debugger or create a custom build of DAPLink.
 * The LPC11U35 does not have a bootloader, so you cannot use bootloader updates on this interface.

--- a/docs/BOOTLOADER_UPDATES.md
+++ b/docs/BOOTLOADER_UPDATES.md
@@ -1,0 +1,24 @@
+# Bootloader updates
+
+DAPLink has the ability to bundle the bootloader firmware with the interface firmware and apply a bootloader update on the first boot of the interface. This allows bootloader updates to be applied as the same time as interface updates and without any special instructions for the user.
+
+### Enabling bootloader updates
+
+To enable bootloader updates for a board or interface circuit the value ```DAPLINK_BOOTLOADER_UPDATE``` must be defined. Once defined, the normal release process which documented on the [developers guide](DEVELOPERS-GUIDE.md) can be used to create firmware for all targets.
+
+### Safety when updating the bootloader
+
+The vector table of the bootloader is erased and replaced during the update. Because of this, there is a small window of time where if power is lost the device will be in a non-bootable state since it does not have a valid vector table. To minimize the time without a valid vector table and the reduce risk the bootloader vector table is replaced with the interface's vector table before the update is performed. This way while the bulk of the bootloader is being loaded there is a valid vector table and a loss of power event does not prevent the device from booting. The update process is shown below with the critical sections where power cannot be lost showin in bold:
+1. **Erase the boot vector table and program the intenterface's vector table to this location**
+1. Erase and program each sector of the bootloader with the new firmware
+1. **Erase the boot vector table and program the new bootloader's vector table to this location**
+
+Other checks
+* If the current bootloader has a valid signature and a version greater than the bootloader stored in interfacer has, the update will not be applied.
+* The interface does a checksum over itself to check for any corruption. If the interface is found to be corrupt the bootloader update will not be applied and an assert will appear on the device.
+* If the current bootloader is identical to the bootloader stored in the interface the update will not be applied.
+
+### Dangers
+* The DAPLink bootloader has a fixed location for where the interface is loaded (typically an offset of 0x8000 from the start of rom). If the bootloader you updated from had a different offset then the interface firmware you used with that bootloader will no longer work. You must use interface firmware built for the new offset.
+* This mechanism does not support downgrading or loading 3rd party bootloaders. To do this a debugger must be used or a custom build of DAPLink must be created.
+* The LPC11U35 does not have a bootloader, so bootloader updates cannot be used on this interface.

--- a/records/hic_hal/k20dx.yaml
+++ b/records/hic_hal/k20dx.yaml
@@ -11,6 +11,7 @@ common:
     includes:
         - source/hic_hal/freescale/k20dx
         - source/hic_hal/freescale/k20dx/MK20D5
+        - projectfiles/uvision/k20dx_bl/build
     sources:
         hic_hal:
             - source/hic_hal/freescale

--- a/records/hic_hal/kl26z.yaml
+++ b/records/hic_hal/kl26z.yaml
@@ -11,6 +11,7 @@ common:
     includes:
         - source/hic_hal/freescale/kl26z
         - source/hic_hal/freescale/kl26z/MKL26Z4
+        - projectfiles/uvision/kl26z_bl/build
     sources:
         hic_hal:
             - source/hic_hal/freescale

--- a/records/hic_hal/sam3u2c.yaml
+++ b/records/hic_hal/sam3u2c.yaml
@@ -8,6 +8,7 @@ common:
     includes:
         - source/hic_hal/atmel/sam3u2c
         - source/hic_hal/atmel/sam3u2c
+        - projectfiles/uvision/sam3u2c_bl/build
     sources:
         hic_hal:
             - source/hic_hal/atmel/sam3u2c

--- a/source/daplink/bootloader.h
+++ b/source/daplink/bootloader.h
@@ -1,0 +1,36 @@
+/**
+ * @file    bootloader.h
+ * @brief   Information about different Hardware Interface Circuits the firmware runs
+ *
+ * DAPLink Interface Firmware
+ * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BOOTLOADER_H
+#define BOOTLOADER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Check to see if an update should be applied and if so apply it
+void bootloader_check_and_update(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/source/daplink/interface/bootloader_update.c
+++ b/source/daplink/interface/bootloader_update.c
@@ -1,0 +1,104 @@
+/**
+ * @file    bootloader_update.c
+ * @brief   Logic to perform a bootloader update when enabled
+ *
+ * DAPLink Interface Firmware
+ * Copyright (c) 2016-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdbool.h>
+#include <string.h>
+#include "flash_manager.h"
+#include "util.h"
+#include "bootloader.h"
+#include "info.h"
+#include "daplink.h"
+#include "crc.h"
+
+// Supress the warning 'null argument provided for parameter marked with attribute "nonnull"'
+// since the vector table is at address 0
+#pragma diag_suppress 2748
+
+#if !defined(DAPLINK_BOOTLOADER_UPDATE)
+    #define DAPLINK_BOOTLOADER_UPDATE       0
+#endif
+
+#if DAPLINK_BOOTLOADER_UPDATE
+    // The bootloader must be built first or this header will not be found
+    #include "bootloader_image.c"
+#else
+    static const unsigned int image_start = 0;
+    static const unsigned int image_size = 0;
+    static const char image_data[1];
+#endif
+
+static bool interface_image_valid()
+{
+    uint32_t stored_crc;
+    uint32_t computed_crc;
+    
+    stored_crc = *(uint32_t *)(DAPLINK_ROM_IF_START + DAPLINK_ROM_IF_SIZE - 4);
+    computed_crc = crc32((void *)DAPLINK_ROM_IF_START, DAPLINK_ROM_IF_SIZE - 4);
+    return computed_crc == stored_crc;
+}
+
+void bootloader_check_and_update(void)
+{
+    int same;
+    error_t ret;
+    bool update_present = image_size > 0;
+
+    if (!update_present) {
+        return;
+    }
+
+    if (info_get_bootloader_present() &&
+            (info_get_bootloader_version() > DAPLINK_VERSION)) {
+        // Bootloader is more recent than the one we have so
+        // don't change it
+        return;
+    }
+
+    if (!interface_image_valid()) {
+        // The interface is corrupt so don't attempt
+        // to apply the update
+        util_assert(0);
+        return;
+    }
+
+    same = memcmp((void*)image_start, image_data, image_size) == 0;
+    if (!same) {
+        flash_manager_set_page_erase(false);
+        ret = flash_manager_init(flash_intf_iap_protected);
+        if (ret != ERROR_SUCCESS) {
+            util_assert(0);
+            return;
+        }
+
+        ret = flash_manager_data(image_start, (const uint8_t*)image_data, image_size);
+        if (ret != ERROR_SUCCESS) {
+            flash_manager_uninit();
+            util_assert(0);
+            return;
+        }
+
+        ret = flash_manager_uninit();
+        if (ret != ERROR_SUCCESS) {
+            util_assert(0);
+            return;
+        }
+    }
+}

--- a/source/daplink/interface/main.c
+++ b/source/daplink/interface/main.c
@@ -38,6 +38,7 @@
 #include "daplink.h"
 #include "util.h"
 #include "DAP.h"
+#include "bootloader.h"
 
 // Event flags for main task
 // Timers events
@@ -211,8 +212,10 @@ __task void main_task(void)
     uint8_t thread_started = 0;
     // button state
     main_reset_state_t main_reset_button_state = MAIN_RESET_RELEASED;
-    // Initialize settings
+    // Initialize settings - required for asserts to work
     config_init();
+    // Update bootloader if it is out of date
+    bootloader_check_and_update();
     // Get a reference to this task
     main_task_id = os_tsk_self();
     // leds

--- a/tools/build_release_uvision.bat
+++ b/tools/build_release_uvision.bat
@@ -42,6 +42,10 @@ if [%1]==[] pip install -r requirements.txt
 if not [%1]==[] pip install -r %1
 pip freeze                                      > uvision_release\build_requirements.txt
 
+@REM build bootloader images first (In the future this should be done with a pattern like *_bl)
+progen generate -t uvision -b -p kl26z_bl
+progen generate -t uvision -b -p k20dx_bl
+progen generate -t uvision -b -p sam3u2c_bl
 @REM build but continue if there are errors
 progen generate -t uvision -b
 @set level=%errorlevel%

--- a/tools/copy_release_files.py
+++ b/tools/copy_release_files.py
@@ -42,6 +42,8 @@ OPTIONAL_COPY_PATTERN_LIST = [
     "%s_crc_legacy_0x8000.bin",
     "%s_crc_legacy_0x5000.bin",
     "%s_crc_legacy.txt",
+    "%s_crc_legacy.txt",
+    "%s_crc.c",
 ]
 
 


### PR DESCRIPTION
Allow bootloader builds to be created by defining DAPLINK_BOOTLOADER_UPDATE. When this is defined the bootloader image will be built into the interface. When the interface runs for the first time it will update the bootloader.
