### PR TITLE
Only copy flash algo to ram once

### DIFF
--- a/source/daplink/interface/swd_host.c
+++ b/source/daplink/interface/swd_host.c
@@ -585,12 +585,6 @@ static uint8_t swd_write_debug_state(DEBUG_STATE *state)
         return 0;
     }
 
-    if (!swd_write_memory(target_device.flash_algo->algo_start,
-                          (uint8_t *)target_device.flash_algo->algo_blob,
-                          target_device.flash_algo->algo_size)) {
-        return 0;
-    }
-
     if (!swd_write_word(DBG_HCSR, DBGKEY | C_DEBUGEN)) {
         return 0;
     }


### PR DESCRIPTION
On each flash algorithm call the flash algorithm blob is copied to ram. This is unnecessary and slows down flash programming. This patch removes the code in swd_write_debug_state responsible for this copy on every flash algo call.