### PR TITLE
Add support for the VBLUno51 board

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -297,3 +297,7 @@ projects:
         - *module_if
         - *module_hic_sam3u2c
         - records/board/ublox_evk_nina_b1.yaml
+    lpc11u35_vbluno51_if:
+        - *module_if
+        - *module_hic_lpc11u35
+        - records/board/vbluno51.yaml    

--- a/records/board/vbluno51.yaml
+++ b/records/board/vbluno51.yaml
@@ -1,0 +1,11 @@
+common:
+    macros:
+        - IO_CONFIG_OVERRIDE        
+    includes:
+        - source/board/override_vbluno51
+    sources:
+        board:
+            - source/board/vbluno51.c
+        target:
+            - source/target/nordic/nrf51822/target_32.c
+            - source/target/nordic/target_reset.c

--- a/source/board/override_vbluno51/IO_Config_Override.h
+++ b/source/board/override_vbluno51/IO_Config_Override.h
@@ -1,0 +1,113 @@
+/**
+ * @file    IO_Config_Override.c
+ * @brief   Alternative IO for LPC11U35 based Hardware Interface Circuit
+ *
+ * DAPLink Interface Firmware
+ * Copyright (c) 2009-2017, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The VBLUno51 board use PIO0_9(18) pin for TGT_SWCLK function.
+ * Because it uses RTS/CTS pins for UART Hardware flow control feature.
+ */
+
+#ifndef __IO_CONFIG_H__
+#define __IO_CONFIG_H__
+
+#include "LPC11Uxx.h"
+#include "daplink.h"
+
+// This GPIO configuration is only valid for the LPC11U35 HIC
+COMPILER_ASSERT(DAPLINK_HIC_ID == DAPLINK_HIC_ID_LPC11U35);
+
+// Peripheral register bit masks (used for pin inits)
+#define FUNC_0                          0
+#define FUNC_1                          1
+#define PULL_DOWN_ENABLED               (1 << 3)
+#define PULL_UP_ENABLED                 (2 << 3)
+#define OPENDRAIN                       (1 << 10)
+
+// DAP LED                              PIO0_21
+#define PIN_DAP_LED_PORT                0
+#define PIN_DAP_LED_BIT                 21
+#define PIN_DAP_LED                     (1 << PIN_DAP_LED_BIT)
+#define PIN_DAP_LED_IOCON               LPC_IOCON->PIO0_21
+#define PIN_DAP_LED_IOCON_INIT          (FUNC_0 | PULL_UP_ENABLED)
+
+// MSD LED                              PIO0_20
+#define PIN_MSD_LED_PORT                0
+#define PIN_MSD_LED_BIT                 20
+#define PIN_MSD_LED                     (1 << PIN_MSD_LED_BIT)
+#define PIN_MSD_LED_IOCON               LPC_IOCON->PIO0_20
+#define PIN_MSD_LED_IOCON_INIT          (FUNC_0 | PULL_UP_ENABLED)
+
+// CDC LED                              PIO0_11
+#define PIN_CDC_LED_PORT                0
+#define PIN_CDC_LED_BIT                 11
+#define PIN_CDC_LED                     (1 << PIN_CDC_LED_BIT)
+#define PIN_CDC_LED_IOCON               LPC_IOCON->TDI_PIO0_11
+#define PIN_CDC_LED_IOCON_INIT          (FUNC_1 | PULL_UP_ENABLED)
+
+// Non-Forwarded Reset in PIN           PIO1_19
+#define PIN_RESET_IN_PORT               1
+#define PIN_RESET_IN_BIT                19
+#define PIN_RESET_IN                    (1 << PIN_RESET_IN_BIT)
+#define PIN_RESET_IN_IOCON              LPC_IOCON->PIO1_19
+#define PIN_RESET_IN_IOCON_INIT         (FUNC_0 | OPENDRAIN | PULL_UP_ENABLED)
+
+// Forwarded Reset in PIN               PIO0_1
+#define PIN_RESET_IN_FWRD_PORT          0
+#define PIN_RESET_IN_FWRD_BIT           1
+#define PIN_RESET_IN_FWRD               (1 << PIN_RESET_IN_FWRD_BIT)
+#define PIN_RESET_IN_FWRD_IOCON         LPC_IOCON->PIO0_1
+#define PIN_RESET_IN_FWRD_IOCON_INIT    (FUNC_0 | OPENDRAIN | PULL_UP_ENABLED)
+
+// nRESET OUT Pin                       PIO0_2
+#define PIN_nRESET_PORT                 0
+#define PIN_nRESET_BIT                  2
+#define PIN_nRESET                      (1 << PIN_nRESET_BIT)
+#define PIN_nRESET_IOCON                LPC_IOCON->PIO0_2
+#define PIN_nRESET_IOCON_INIT           (FUNC_0 | OPENDRAIN | PULL_UP_ENABLED)
+
+// SWCLK/TCK Pin                        PIO0_9
+#define PIN_SWCLK_PORT                  0
+#define PIN_SWCLK_BIT                   9
+#define PIN_SWCLK                       (1 << PIN_SWCLK_BIT)
+#define PIN_SWCLK_TCK_IOCON             LPC_IOCON->PIO0_9
+#define PIN_SWCLK_TCK_IOCON_INIT        (FUNC_0 | PULL_UP_ENABLED)
+
+// SWDIO/TMS In/Out Pin                 PIO0_8
+#define PIN_SWDIO_PORT                  0
+#define PIN_SWDIO_BIT                   8
+#define PIN_SWDIO                       (1 << PIN_SWDIO_BIT)
+#define PIN_SWDIO_TMS_IOCON             LPC_IOCON->PIO0_8
+#define PIN_SWDIO_TMS_IOCON_INIT        (FUNC_0 | PULL_UP_ENABLED)
+
+// TDI Pin                              PIO0_17
+#define PIN_TDI_PORT                    17
+#define PIN_TDI_BIT                     17
+#define PIN_TDI                         (1 << PIN_TDI_BIT)
+#define PIN_TDI_IOCON                   LPC_IOCON->PIO0_17
+#define PIN_TDI_IOCON_INIT              (FUNC_0 | PULL_UP_ENABLED)
+
+// SWO/TDO Pin                          PIO0_9
+#define PIN_TDO_PORT                    9
+#define PIN_TDO_BIT                     9
+#define PIN_TDO                         (1 << PIN_TDO_BIT)
+#define PIN_TDO_IOCON                   LPC_IOCON->PIO0_9
+#define PIN_TDO_IOCON_INIT              (FUNC_0 | PULL_UP_ENABLED)
+
+#endif

--- a/source/board/vbluno51.c
+++ b/source/board/vbluno51.c
@@ -1,0 +1,42 @@
+/**
+ * @file    vbluno51.c
+ * @brief   Board ID for the VBLUno51 board (VNG Bluetooth Low Energy UNO nRF51822 board)
+ *
+ * DAPLink Interface Firmware
+ * Copyright (c) 2009-2017, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "virtual_fs.h"
+#include "uart.h"
+
+const char *board_id = "C006";
+
+// Override default behavior
+//
+// URL_NAME and DRIVE_NAME must be 11 characters excluding
+// the null terminated character
+// Note - 4 byte alignemnt required as workaround for ARMCC compiler bug with weak references
+__attribute__((aligned(4)))
+const vfs_filename_t daplink_url_name =       "VBLUNO51HTM";
+__attribute__((aligned(4)))
+const vfs_filename_t daplink_drive_name =     "DAPLINK    ";
+__attribute__((aligned(4)))
+const char *const daplink_target_url = "https://vngiotlab.github.io/vbluno/";
+
+void prerun_board_config()
+{
+    uart_enable_flow_control(true);
+}

--- a/source/hic_hal/nxp/lpc11u35/uart.c
+++ b/source/hic_hal/nxp/lpc11u35/uart.c
@@ -40,6 +40,8 @@ uint8_t write_buffer_data[BUFFER_SIZE];
 circ_buf_t read_buffer;
 uint8_t read_buffer_data[BUFFER_SIZE];
 
+static uint8_t flow_control_enabled = 0;
+
 static int32_t reset(void);
 
 int32_t uart_initialize(void)
@@ -147,7 +149,7 @@ int32_t uart_set_configuration(UART_Configuration *config)
             break;
     }
 
-    if (config->FlowControl == UART_FLOW_CONTROL_RTS_CTS) {
+    if (flow_control_enabled) {
         LPC_IOCON->PIO0_17 |= 0x01;     // RTS
         LPC_IOCON->PIO0_7  |= 0x01;     // CTS
         // enable auto RTS and CTS
@@ -249,7 +251,12 @@ int32_t uart_get_configuration(UART_Configuration *config)
     }
 
     // get flow control
-    config->FlowControl = UART_FLOW_CONTROL_NONE;
+    if (flow_control_enabled) {
+    	config->FlowControl = UART_FLOW_CONTROL_RTS_CTS;
+    }
+    else {
+    	config->FlowControl = UART_FLOW_CONTROL_NONE;
+    }
     return 1;
 }
 
@@ -283,7 +290,7 @@ int32_t uart_read_data(uint8_t *data, uint16_t size)
 
 void uart_enable_flow_control(bool enabled)
 {
-    // Flow control not implemented for this platform
+    flow_control_enabled = (uint8_t)enabled;
 }
 
 void UART_IRQHandler(void)

--- a/test/info.py
+++ b/test/info.py
@@ -74,6 +74,7 @@ PROJECT_RELEASE_INFO = {
     ('lpc11u35_wizwiki_w7500_eco_if',               False,      0x0000,     "bin"       ),
     ('lpc11u35_wizwiki_w7500p_if',                  False,      0x0000,     "bin"       ),
     ("sam3u2c_ublox_evk_nina_b1_if",                True,       0x5000,     "bin"       ),
+    ("lpc11u35_vbluno51_if",                        False,      0x0000,     "bin"       ),
 }
 
 # All supported configurations
@@ -140,6 +141,7 @@ SUPPORTED_CONFIGURATIONS = [
     (   0x2202,     'lpc11u35_wizwiki_w7500_eco_if',            None,               'WIZWIKI_W7500ECO'                      ),
     (   0x2203,     'lpc11u35_wizwiki_w7500p_if',               None,               'WIZWIKI_W7500P'                        ),
     (   0x1237,     'sam3u2c_ublox_evk_nina_b1_if',            'sam3u2c_bl',        'U-BLOX-EVK-NINA-B1'                    ),
+    (   0xC006,     'lpc11u35_vbluno51_if',                     None,               'VNG-VBLUno51'                          ),    
 ]
 
 # Add new HICs here
@@ -187,7 +189,8 @@ TARGET_WITH_BAD_VECTOR_TABLE_LIST = [
     'Seeed-Arch-Link',
     'SSCI-MBIT',
     'BlueNinja',
-    'U-BLOX-EVK-NINA-B1',]
+    'U-BLOX-EVK-NINA-B1',
+    'VNG-VBLUno51']
 
 BOARD_ID_TO_BUILD_TARGET = {config[0]: config[3] for config in
                             SUPPORTED_CONFIGURATIONS}


### PR DESCRIPTION
Add support for the VBLUno51 board

Email from Sarah Marsh (mbed):
************************************
Hi,

Here is your daplink board ID: C006
The slug: VBLUNO51

When I execute mbedls, it looks like you have used the DAPLink ID for the NRF51_DK. You need your own unique ID. We are running the tests with the NRF51_DK ID mocked as your platform, but you will need to do the following to be mbed enabled:

Please submit a PR against mbed-ls (https://github.com/ARMmbed/mbed-ls), so your board can be detected with our tools.

Please also submit a PR against DAPLink (https://github.com/mbedmicro/DAPLink), so that your board is uniquely identifiable.

Thanks,
Sarah
************************************

The VBLUno51 board was added to mbed-os 5.5.2 released
https://github.com/ARMmbed/mbed-os/pull/4629
https://github.com/ARMmbed/mbed-os/pull/4719

Signed-off-by: iotvietmember <robotden@gmail.com>