### PR TITLE
Disable UART when target device in reset state

### DIFF
--- a/source/daplink/usb2uart/usbd_user_cdc_acm.c
+++ b/source/daplink/usb2uart/usbd_user_cdc_acm.c
@@ -116,6 +116,7 @@ int32_t USBD_CDC_ACM_SendBreak(uint16_t dur)
     if (dur != 0) {
         start_break_time = os_time_get();
         target_set_state(RESET_HOLD);
+        uart_uninitialize();
     } else {
         end_break_time = os_time_get();
 
@@ -124,6 +125,8 @@ int32_t USBD_CDC_ACM_SendBreak(uint16_t dur)
             main_reset_target(1);
         } else {
             main_reset_target(0);
+            // Re-initialize the UART after target reset is cleared.
+            uart_initialize();
         }
     }
 


### PR DESCRIPTION
During UART break, target device is set to reset. UART may capture noise as data during this reset period. Disable UART and initialize it back when device is out of reset.