### PR TITLE
Fix USB uframe rate on atsam3u

### DIFF
--- a/source/hic_hal/atmel/sam3u2c/usbd_ATSAM3U2C.c
+++ b/source/hic_hal/atmel/sam3u2c/usbd_ATSAM3U2C.c
@@ -648,26 +648,26 @@ void USBD_Handler(void)
 
     /* Start of Frame Interrupt                                                 */
     if (intsta & UDPHS_INTSTA_INT_SOF) {
-        if (USBD_HighSpeed == 0) {
-#ifdef __RTX
-            UDPHS->UDPHS_CLRINT = UDPHS_CLRINT_INT_SOF;
+        /* Process the SOF interrupt even in high speed mode.
+        The SOF and MICRO_SOF interrupt are never generated at the same
+        time. Instead, when in high speed mode there is 1 SOF
+        interrupt and 7 MICRO_SOF interrupts every 1ms. */
 
-            if (USBD_RTX_DevTask) {
-                isr_evt_set(USBD_EVT_SOF, USBD_RTX_DevTask);
-            }
+#ifdef __RTX
+        UDPHS->UDPHS_CLRINT = UDPHS_CLRINT_INT_SOF;
+
+        if (USBD_RTX_DevTask) {
+            isr_evt_set(USBD_EVT_SOF, USBD_RTX_DevTask);
+        }
 
 #else
 
-            if (USBD_P_SOF_Event) {
-                USBD_P_SOF_Event();
-            }
-
-            UDPHS->UDPHS_CLRINT = UDPHS_CLRINT_INT_SOF;
-#endif
-
-        } else {
-            UDPHS->UDPHS_CLRINT = UDPHS_CLRINT_INT_SOF;
+        if (USBD_P_SOF_Event) {
+            USBD_P_SOF_Event();
         }
+
+        UDPHS->UDPHS_CLRINT = UDPHS_CLRINT_INT_SOF;
+#endif
     }
 
     /* Micro Frame Interrupt                                                    */


### PR DESCRIPTION
When in high speed mode, the atsam3u hal drops start of frame SOF interrupts. This causes a MICRO_SOF rate 1/8 slower than it should be since SOF and MICRO_SOF never occur at the same time. This patch fixes that problem by processing SOF interrupts in addition to MICRO_SOF interrupts.

Note - When in USB test mode during the USB tests, the timing occasionally caused the atsam3u to only receive SOF interrupts and no MICRO_SOF interrupts for more than 10s at a time. When in this state the CDC port would stop sending UART data to the host PC, since CDC IN transfers are started on the start of frame handling which was only triggered by a MICRO_SOF interrupt. This caused an intermittent serial read timeout in the when running the all endpoint test. With the addition of processing SOF interrupts, both types of frame interrupts are handled, so frame handling can't be starved by too many of one type.