### PR TITLE
Update Python version requirement

### DIFF
--- a/docs/DEVELOPERS-GUIDE.md
+++ b/docs/DEVELOPERS-GUIDE.md
@@ -3,7 +3,7 @@
 ## Setup
 Install the necessary tools listed below. Skip any step where a compatible tool already exists.
 
-* Install [Python 2.7.9 or above](https://www.python.org/downloads/) . Add to PATH.
+* Install [Python 2, 2.7.9 or above](https://www.python.org/downloads/) . Add to PATH.
 * Install [Git](https://git-scm.com/downloads) . Add to PATH.
 * Install [Keil MDK-ARM](https://www.keil.com/download/product/), preferably version 5. Set environment variable "UV4" to the absolute path of the UV4 executable if you don't install to the default location. Note that "UV4" is what's used for both MDK versions 4 and 5.
 * Install virtualenv in your global Python installation eg: `pip install virtualenv`


### PR DESCRIPTION
mbed-ls is required by DAPLink, but the install scripts of mbed-ls doesn't support Python3 now.