### PR TITLE
Test: BL is flashed before IF when --loadbl set. 

### DIFF
--- a/test/daplink_board.py
+++ b/test/daplink_board.py
@@ -28,7 +28,7 @@ import itertools
 import mbed_lstools
 import info
 import test_daplink
-from test_info import TestInfoStub
+from test_info import TestInfoStub, TestInfo
 from intelhex import IntelHex
 from pyOCD.board import MbedBoard
 
@@ -409,6 +409,9 @@ class DaplinkBoard(object):
 
     def load_interface(self, filepath, parent_test):
         """Load an interface binary or hex"""
+        assert isinstance(filepath, str), "Invalid bootloader image!"
+        assert isinstance(parent_test, TestInfo), "Invalid parent test object!"
+
         test_info = parent_test.create_subtest('load_interface')
         self.set_mode(self.MODE_BL, test_info)
 
@@ -440,6 +443,9 @@ class DaplinkBoard(object):
 
     def load_bootloader(self, filepath, parent_test):
         """Load a bootloader binary or hex"""
+        assert isinstance(filepath, str), "Invalid bootloader image!"
+        assert isinstance(parent_test, TestInfo), "Invalid parent test object!"
+
         test_info = parent_test.create_subtest('load_bootloader')
         self.set_mode(self.MODE_IF, test_info)
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -223,14 +223,14 @@ class TestManager(object):
                            test_configuration.bl_firmware)
             test_info.info("Target: %s" % test_configuration.target)
 
-            if self._load_if:
-                if_path = test_configuration.if_firmware.hex_path
-                board.load_interface(if_path, test_info)
-
             valid_bl = test_configuration.bl_firmware is not None
             if self._load_bl and valid_bl:
                 bl_path = test_configuration.bl_firmware.hex_path
                 board.load_bootloader(bl_path, test_info)
+
+            if self._load_if:
+                if_path = test_configuration.if_firmware.hex_path
+                board.load_interface(if_path, test_info)
 
             board.set_check_fs_on_remount(True)
 


### PR DESCRIPTION
Before we start testing, a set of functions may validate and fix environment
where necessary and possible.

This fixes intermittent missing bootloader blocking issue.
Test suite will search for broken bootloader artifacts and fix where possible.

Signed-off-by: CeDeROM Tomasz CEDRO <tomek@cedro.info>