### PR TITLE
Base IAP device info on memory map

### DIFF
--- a/source/board/k20dx_bl.c
+++ b/source/board/k20dx_bl.c
@@ -20,8 +20,14 @@
  */
 
 #include "target_config.h"
+#include "daplink_addr.h"
+#include "compiler.h"
 
 const char *board_id   = "0000";
+
+// Warning - changing the interface start will break backwards compatibility
+COMPILER_ASSERT(DAPLINK_ROM_IF_START == KB(32));
+COMPILER_ASSERT(DAPLINK_ROM_IF_SIZE == KB(95));
 
 // k20dx128 target information
 target_cfg_t target_device = {
@@ -29,9 +35,9 @@ target_cfg_t target_device = {
     // Assume memory is regions are same size. Flash algo should ignore requests
     //  when variable sized sectors exist
     // .sector_cnt = ((.flash_end - .flash_start) / .sector_size);
-    .sector_cnt     = ((KB(127) - KB(32)) / 1024),
-    .flash_start    = KB(32),
-    .flash_end      = KB(127),
+    .sector_cnt     = (DAPLINK_ROM_IF_SIZE / 1024),
+    .flash_start    = DAPLINK_ROM_IF_START,
+    .flash_end      = DAPLINK_ROM_IF_START + DAPLINK_ROM_IF_SIZE,
     .ram_start      = 0x1fffe000,
     .ram_end        = 0x20002000,
     /* .flash_algo not needed for bootloader */

--- a/source/board/kl26z_bl.c
+++ b/source/board/kl26z_bl.c
@@ -20,8 +20,14 @@
  */
 
 #include "target_config.h"
+#include "daplink_addr.h"
+#include "compiler.h"
 
 const char *board_id = "0000";
+
+// Warning - changing the interface start will break backwards compatibility
+COMPILER_ASSERT(DAPLINK_ROM_IF_START == KB(32));
+COMPILER_ASSERT(DAPLINK_ROM_IF_SIZE == KB(95));
 
 // kl26z128 target information
 target_cfg_t target_device = {
@@ -29,9 +35,9 @@ target_cfg_t target_device = {
     // Assume memory is regions are same size. Flash algo should ignore requests
     //  when variable sized sectors exist
     // .sector_cnt = ((.flash_end - .flash_start) / .sector_size);
-    .sector_cnt     = ((KB(127) - KB(32)) / 1024),
-    .flash_start    = KB(32),
-    .flash_end      = KB(127),
+    .sector_cnt     = (DAPLINK_ROM_IF_SIZE / 1024),
+    .flash_start    = DAPLINK_ROM_IF_START,
+    .flash_end      = DAPLINK_ROM_IF_START + DAPLINK_ROM_IF_SIZE,
     .ram_start      = 0x1FFFF000,
     .ram_end        = 0x20003000,
     /* .flash_algo not needed for bootloader */

--- a/source/board/lpc4322_bl.c
+++ b/source/board/lpc4322_bl.c
@@ -20,8 +20,14 @@
  */
 
 #include "target_config.h"
+#include "daplink_addr.h"
+#include "compiler.h"
 
 const char *board_id   = "0000";
+
+// Warning - changing the interface start will break backwards compatibility
+COMPILER_ASSERT(DAPLINK_ROM_IF_START == 0x1A010000);
+COMPILER_ASSERT(DAPLINK_ROM_IF_SIZE == (0x1A030000 - 0x1A010000));
 
 // lpc4322 target information
 target_cfg_t target_device = {
@@ -30,8 +36,8 @@ target_cfg_t target_device = {
     //  when variable sized sectors exist
     // .sector_cnt = ((.flash_end - .flash_start) / .sector_size);
     .sector_cnt     = 2,
-    .flash_start    = 0x1A010000,
-    .flash_end      = 0x1A030000,
+    .flash_start    = DAPLINK_ROM_IF_START,
+    .flash_end      = DAPLINK_ROM_IF_START + DAPLINK_ROM_IF_SIZE,
     .ram_start      = 0x10000000,
     .ram_end        = 0x10008000,
     /* .flash_algo not needed for bootloader */

--- a/source/board/sam3u2c_bl.c
+++ b/source/board/sam3u2c_bl.c
@@ -20,8 +20,14 @@
  */
 
 #include "target_config.h"
+#include "daplink_addr.h"
+#include "compiler.h"
 
 const char *board_id = "0000";
+
+// Warning - changing the interface start will break backwards compatibility
+COMPILER_ASSERT(DAPLINK_ROM_IF_START == (0x00080000 + KB(32)));
+COMPILER_ASSERT(DAPLINK_ROM_IF_SIZE == (KB(124) - KB(32)));
 
 // atsam3u2c target information
 target_cfg_t target_device = {
@@ -29,9 +35,9 @@ target_cfg_t target_device = {
     // Assume memory is regions are same size. Flash algo should ignore requests
     //  when variable sized sectors exist
     // .sector_cnt = ((.flash_end - .flash_start) / .sector_size);
-    .sector_cnt     = ((KB(128) - KB(32)) / 0x1000),
-    .flash_start    = 0x00080000 + KB(32),
-    .flash_end      = 0x00080000 + KB(128),
+    .sector_cnt     = (DAPLINK_ROM_IF_SIZE / 0x1000),
+    .flash_start    = DAPLINK_ROM_IF_START,
+    .flash_end      = DAPLINK_ROM_IF_START + DAPLINK_ROM_IF_SIZE,
     .ram_start      = 0x2007C000,
     .ram_end        = 0x20084000
     /* .flash_algo not needed for bootloader */


### PR DESCRIPTION
Ensure a device's memory map is kept in sync with its device info by using memory map defines and asserting on an unintended change.