### PR TITLE
Disable UART HWFC

### DIFF
--- a/source/board/vbluno51.c
+++ b/source/board/vbluno51.c
@@ -36,5 +36,5 @@ const char *const daplink_target_url = "https://os.mbed.com/platforms/VBLUNO51/"
 
 void prerun_board_config()
 {
-    uart_enable_flow_control(true);
+    uart_enable_flow_control(false);
 }


### PR DESCRIPTION
For mbed Online Compiler because the VBLUNO51 use nrf51822 target

Signed-off-by: iotvietmember <robotden@gmail.com>