### PR TITLE
Fix ram end for kl82z

### DIFF
--- a/source/target/freescale/kl82z/target.c
+++ b/source/target/freescale/kl82z/target.c
@@ -31,6 +31,6 @@ target_cfg_t target_device = {
     .flash_start    = 0,
     .flash_end      = KB(128),
     .ram_start      = 0x1FFFA000,
-    .ram_end        = 0x2002000,
+    .ram_end        = 0x20012000,
     .flash_algo     = (program_target_t *) &flash,
 };


### PR DESCRIPTION
Fix typo in target_device for the kl82z. This fixes programming for this device.